### PR TITLE
Replace ASCII diagrams with mermaid in foundation docs

### DIFF
--- a/docs/00-foundations/01-getting-oriented.md
+++ b/docs/00-foundations/01-getting-oriented.md
@@ -71,22 +71,25 @@ Your work survives terminal closes, laptop sleeps, and SSH disconnects.
 
 This is what you see after running `dev`:
 
-```
-+------------------------------------------+---------------------+
-|                                          |                     |
-|  Neovim                                  |  Shell              |
-|                                          |                     |
-|  ~ open files here                       |  $ run commands     |
-|  ~ search code here                      |  $ tests            |
-|  ~ LSP features here                     |  $ git              |
-|  ~ formatting here                       |  $ make / uv        |
-|                                          |  $ logs             |
-|                                          |  $ AI tools         |
-|                                          |                     |
-|  [F5] search  [F6] files  [F8] explorer  |                     |
-|                                          |                     |
-+------------------------------------------+---------------------+
-  tmux pane 1 (editor)                       tmux pane 2 (shell)
+```mermaid
+block-beta
+  columns 2
+  block:editor["tmux pane 1 — Neovim (60%)"]
+    columns 1
+    e1["open files"]
+    e2["search code"]
+    e3["LSP features"]
+    e4["formatting"]
+    e5["F5 search · F6 files · F8 explorer"]
+  end
+  block:shell["tmux pane 2 — Shell (40%)"]
+    columns 1
+    s1["run commands"]
+    s2["tests"]
+    s3["git"]
+    s4["make / uv"]
+    s5["logs · AI tools"]
+  end
 ```
 
 The left pane takes about 60% of the width. Neovim opens there automatically.

--- a/docs/00-foundations/02-mental-model.md
+++ b/docs/00-foundations/02-mental-model.md
@@ -10,25 +10,17 @@ same job.
 
 ## The Three Layers
 
-```
-+---------------------------------------------------------------+
-|  Kitty                                                        |
-|  (terminal emulator -- OS windows, tabs, GPU rendering)       |
-|                                                               |
-|  +----------------------------------------------------------+ |
-|  |  tmux                                                    | |
-|  |  (session manager -- panes, windows, persistence)        | |
-|  |                                                          | |
-|  |  +----------------------------+ +----------------------+ | |
-|  |  |  Neovim                    | |  Shell               | | |
-|  |  |  (editor -- code, LSP,    | |  (commands, tests,   | | |
-|  |  |   search, formatting)     | |   git, logs, AI)     | | |
-|  |  |                           | |                      | | |
-|  |  +----------------------------+ +----------------------+ | |
-|  |                                                          | |
-|  +----------------------------------------------------------+ |
-|                                                               |
-+---------------------------------------------------------------+
+```mermaid
+block-beta
+  columns 1
+  block:kitty["Kitty — terminal emulator (OS windows, tabs, GPU rendering)"]
+    columns 1
+    block:tmux["tmux — session manager (panes, windows, persistence)"]
+      columns 2
+      neovim["Neovim\neditor — code, LSP,\nsearch, formatting"]
+      shell["Shell\ncommands, tests,\ngit, logs, AI"]
+    end
+  end
 ```
 
 Each layer wraps the one inside it. They do not overlap.
@@ -95,26 +87,38 @@ Here is what happens when you press a key, depending on where you are:
 
 **You press `Ctrl-a |` (tmux prefix + split)**
 
-```
-Kitty sees: Ctrl-a     --> passes it through (not a kitty binding)
-tmux sees:  Ctrl-a |   --> intercepts it, creates a vertical split
-Neovim:                --> never sees the keypress
+```mermaid
+sequenceDiagram
+    participant K as Kitty
+    participant T as tmux
+    participant N as Neovim
+    K->>T: Ctrl-a (pass through, not a kitty binding)
+    T-xT: Ctrl-a | → intercepts, creates vertical split
+    Note over N: never sees the keypress
 ```
 
 **You press `F5` in the Neovim pane**
 
-```
-Kitty sees: F5         --> passes it through (not a kitty binding)
-tmux sees:  F5         --> passes it through (not a tmux binding)
-Neovim sees: F5        --> opens live grep search
+```mermaid
+sequenceDiagram
+    participant K as Kitty
+    participant T as tmux
+    participant N as Neovim
+    K->>T: F5 (pass through, not a kitty binding)
+    T->>N: F5 (pass through, not a tmux binding)
+    N-xN: F5 → opens live grep search
 ```
 
 **You press `F5` in the shell pane**
 
-```
-Kitty sees: F5         --> passes it through
-tmux sees:  F5         --> passes it through
-Shell sees: F5         --> nothing happens (F5 is not bound in the shell)
+```mermaid
+sequenceDiagram
+    participant K as Kitty
+    participant T as tmux
+    participant S as Shell
+    K->>T: F5 (pass through)
+    T->>S: F5 (pass through)
+    Note over S: nothing happens (F5 not bound in shell)
 ```
 
 The layers are strict. Each one only intercepts what it owns. If a keypress is


### PR DESCRIPTION
## Summary

- Replace nested ASCII architecture diagram with mermaid `block-beta` showing kitty > tmux > neovim nesting
- Replace two-pane layout ASCII art with mermaid `block-beta` showing editor/shell split
- Replace 3 keypress flow-through ASCII diagrams with mermaid `sequenceDiagram` showing how keypresses cascade through layers

Only the high-value conversions — simple reference tables (keybindings, VS Code mappings) are left as tables since that's the right format for lookup.

## Test plan

- [ ] View `docs/00-foundations/01-getting-oriented.md` on GitHub — confirm layout diagram renders
- [ ] View `docs/00-foundations/02-mental-model.md` on GitHub — confirm architecture and sequence diagrams render

🤖 Generated with [Claude Code](https://claude.com/claude-code)