### PR TITLE
[codex] add markdown preview and managed install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,17 @@ curl -fsSL https://raw.githubusercontent.com/flatherskevin/local/main/install.sh
 wget -qO- https://raw.githubusercontent.com/flatherskevin/local/main/install.sh | bash
 ```
 
-By default this installs or updates the repo at `~/codebase/local` and runs the
-bootstrap flow.
+By default this installs or updates the managed checkout at
+`~/.flatherskevin/local` and runs the bootstrap flow.
+
+Each install run refreshes that managed checkout with a fresh shallow clone of
+`main`.
 
 ## Manual Install
 
 ```bash
-git clone https://github.com/flatherskevin/local.git ~/codebase/local
-cd ~/codebase/local
+git clone --depth 1 --branch main https://github.com/flatherskevin/local.git ~/.flatherskevin/local
+cd ~/.flatherskevin/local
 ./bootstrap/macos.sh
 ```
 
@@ -49,7 +52,7 @@ After install:
 
 ```bash
 source ~/.zshrc
-~/codebase/local/scripts/validate-setup.sh
+~/.flatherskevin/local/scripts/validate-setup.sh
 ```
 
 ## Updating Later

--- a/bootstrap/common.sh
+++ b/bootstrap/common.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-BACKUP_DIR="${HOME}/.dotfiles-backups/$(date +%Y%m%d-%H%M%S)"
+LOCAL_HOME="${LOCAL_BASE_DIR:-${HOME}/.flatherskevin}"
+BACKUP_DIR="${LOCAL_HOME}/backups/$(date +%Y%m%d-%H%M%S)"
 
 log() {
   printf '[dotfiles] %s\n' "$*"
@@ -63,4 +64,3 @@ append_line_once() {
     log "Updated ${file_path}"
   fi
 }
-

--- a/config/nvim/lua/config/autocmds.lua
+++ b/config/nvim/lua/config/autocmds.lua
@@ -18,10 +18,45 @@ vim.api.nvim_create_autocmd("FileType", {
   group = augroup,
   pattern = { "markdown", "gitcommit", "text" },
   desc = "Make prose buffers easier to read and edit",
-  callback = function()
+  callback = function(args)
     vim.opt_local.wrap = true
     vim.opt_local.spell = true
     vim.opt_local.linebreak = true
+
+    -- Keep diagnostics out of prose buffers unless explicitly toggled on.
+    vim.diagnostic.enable(false, { bufnr = args.buf })
+
+    vim.keymap.set("n", "<leader>md", function()
+      local enabled = vim.diagnostic.is_enabled({ bufnr = args.buf })
+      vim.diagnostic.enable(not enabled, { bufnr = args.buf })
+    end, { buffer = args.buf, desc = "Toggle buffer diagnostics" })
   end,
 })
 
+vim.api.nvim_create_autocmd("CursorHold", {
+  group = augroup,
+  pattern = { "*.md", "*.mdx", "*.txt" },
+  desc = "Show diagnostics in a float for prose buffers",
+  callback = function(args)
+    if not vim.diagnostic.is_enabled({ bufnr = args.buf }) then
+      return
+    end
+    if vim.api.nvim_get_current_buf() ~= args.buf or vim.fn.mode() ~= "n" then
+      return
+    end
+
+    local line = vim.api.nvim_win_get_cursor(0)[1] - 1
+    local diagnostics = vim.diagnostic.get(args.buf, { lnum = line })
+    if #diagnostics == 0 then
+      return
+    end
+
+    vim.diagnostic.open_float(args.buf, {
+      scope = "line",
+      focusable = false,
+      close_events = { "CursorMoved", "CursorMovedI", "BufHidden", "InsertEnter" },
+      border = "rounded",
+      source = "if_many",
+    })
+  end,
+})

--- a/config/nvim/lua/config/lazy.lua
+++ b/config/nvim/lua/config/lazy.lua
@@ -14,6 +14,16 @@ vim.opt.rtp:prepend(lazypath)
 require("lazy").setup({
   spec = {
     { "LazyVim/LazyVim", import = "lazyvim.plugins" },
+    { import = "lazyvim.plugins.extras.editor.neo-tree" },
+    { import = "lazyvim.plugins.extras.editor.snacks_picker" },
+    { import = "lazyvim.plugins.extras.lang.go" },
+    { import = "lazyvim.plugins.extras.lang.json" },
+    { import = "lazyvim.plugins.extras.lang.markdown" },
+    { import = "lazyvim.plugins.extras.lang.python" },
+    { import = "lazyvim.plugins.extras.lang.terraform" },
+    { import = "lazyvim.plugins.extras.lang.toml" },
+    { import = "lazyvim.plugins.extras.lang.typescript" },
+    { import = "lazyvim.plugins.extras.lang.yaml" },
     { import = "plugins" },
   },
   defaults = {
@@ -43,4 +53,3 @@ require("lazy").setup({
     },
   },
 })
-

--- a/config/nvim/lua/plugins/editor.lua
+++ b/config/nvim/lua/plugins/editor.lua
@@ -53,5 +53,11 @@ return {
       })
     end,
   },
+  {
+    "iamcco/markdown-preview.nvim",
+    ft = { "markdown" },
+    build = function()
+      vim.fn["mkdp#util#install"]()
+    end,
+  },
 }
-

--- a/config/nvim/lua/plugins/lazyvim.lua
+++ b/config/nvim/lua/plugins/lazyvim.lua
@@ -9,16 +9,4 @@ return {
       },
     },
   },
-
-  { import = "lazyvim.plugins.extras.editor.neo-tree" },
-  { import = "lazyvim.plugins.extras.editor.snacks_picker" },
-
-  { import = "lazyvim.plugins.extras.lang.go" },
-  { import = "lazyvim.plugins.extras.lang.json" },
-  { import = "lazyvim.plugins.extras.lang.markdown" },
-  { import = "lazyvim.plugins.extras.lang.python" },
-  { import = "lazyvim.plugins.extras.lang.terraform" },
-  { import = "lazyvim.plugins.extras.lang.toml" },
-  { import = "lazyvim.plugins.extras.lang.typescript" },
-  { import = "lazyvim.plugins.extras.lang.yaml" },
 }

--- a/docs/00-foundations/03-install-and-validate.md
+++ b/docs/00-foundations/03-install-and-validate.md
@@ -3,8 +3,8 @@
 ## Install
 
 ```bash
-git clone https://github.com/flatherskevin/local.git ~/codebase/local
-cd ~/codebase/local
+git clone --depth 1 --branch main https://github.com/flatherskevin/local.git ~/.flatherskevin/local
+cd ~/.flatherskevin/local
 chmod +x bootstrap/macos.sh scripts/*.sh scripts/dev
 ./bootstrap/macos.sh
 ```
@@ -138,11 +138,11 @@ Lazy will reinstall everything on next launch.
 ls -la ~/.config/tmux/tmux.conf
 ```
 
-It should point to `~/codebase/local/config/tmux/tmux.conf`. If not, re-run
+It should point to `~/.flatherskevin/local/config/tmux/tmux.conf`. If not, re-run
 the bootstrap or manually symlink:
 
 ```bash
-ln -sf ~/codebase/local/config/tmux/tmux.conf ~/.config/tmux/tmux.conf
+ln -sf ~/.flatherskevin/local/config/tmux/tmux.conf ~/.config/tmux/tmux.conf
 tmux source-file ~/.config/tmux/tmux.conf
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -3,21 +3,31 @@
 set -euo pipefail
 
 REPO_URL="${LOCAL_REPO_URL:-https://github.com/flatherskevin/local.git}"
-INSTALL_DIR="${LOCAL_INSTALL_DIR:-$HOME/codebase/local}"
+INSTALL_BASE_DIR="${LOCAL_BASE_DIR:-$HOME/.flatherskevin}"
+INSTALL_DIR="${LOCAL_INSTALL_DIR:-$INSTALL_BASE_DIR/local}"
+INSTALL_REF="${LOCAL_INSTALL_REF:-main}"
+TEMP_DIR=""
+
+cleanup() {
+  if [[ -n "$TEMP_DIR" && -d "$TEMP_DIR" ]]; then
+    rm -rf "$TEMP_DIR"
+  fi
+}
+
+trap cleanup EXIT
 
 printf '[local] install dir: %s\n' "$INSTALL_DIR"
 
 mkdir -p "$(dirname "$INSTALL_DIR")"
+mkdir -p "$INSTALL_BASE_DIR"
 
-if [[ -d "$INSTALL_DIR/.git" ]]; then
-  printf '[local] updating existing repo\n'
-  git -C "$INSTALL_DIR" fetch origin --prune
-  git -C "$INSTALL_DIR" pull --ff-only
-else
-  printf '[local] cloning repo\n'
-  git clone "$REPO_URL" "$INSTALL_DIR"
-fi
+printf '[local] cloning %s (ref: %s)\n' "$REPO_URL" "$INSTALL_REF"
+TEMP_DIR="$(mktemp -d "${INSTALL_BASE_DIR}/local.tmp.XXXXXX")"
+git clone --depth 1 --branch "$INSTALL_REF" "$REPO_URL" "$TEMP_DIR"
+
+rm -rf "$INSTALL_DIR"
+mv "$TEMP_DIR" "$INSTALL_DIR"
+TEMP_DIR=""
 
 chmod +x "$INSTALL_DIR/bootstrap/macos.sh" "$INSTALL_DIR"/scripts/*.sh "$INSTALL_DIR/scripts/dev"
 exec "$INSTALL_DIR/bootstrap/macos.sh"
-

--- a/scripts/dev
+++ b/scripts/dev
@@ -80,6 +80,7 @@ if [[ -z "$project" ]]; then
   exit 0
 fi
 
+project="${project%/}"
 session_name="$(sanitize_session_name "${project#$HOME/}")"
 if [[ -z "$session_name" ]]; then
   session_name="$(sanitize_session_name "$(basename "$project")")"
@@ -102,4 +103,3 @@ if [[ -n "${TMUX:-}" ]]; then
 else
   exec tmux attach-session -t "$session_name"
 fi
-


### PR DESCRIPTION
## Summary
- add `markdown-preview.nvim` as a core Neovim plugin for Markdown buffers
- move LazyVim extras into the top-level lazy spec to satisfy current import-order expectations
- fix prose-buffer diagnostics setup for Neovim 0.12 and trim trailing slashes from tmux session names
- change bootstrap to use a managed checkout under `~/.flatherskevin/local` refreshed from a shallow `main` clone each run
- update install and validation docs to match the managed checkout path

## Why
The repo was still assuming a checkout under `~/codebase/local`, and the current LazyVim/Neovim setup surfaced startup issues around import order and prose-buffer diagnostics. This change makes the install flow self-contained under `~/.flatherskevin`, adds Markdown preview support, and aligns startup behavior with current upstream expectations.

## Validation
- `./scripts/validate-setup.sh`
- `nvim --headless '+edit README.md' '+quitall'`
- `nvim --headless '+Lazy! health' '+qa'`
