### PR TITLE
Show hidden files in Neovim picker, reload nvim on refresh

### DIFF
--- a/config/nvim/lua/plugins/snacks.lua
+++ b/config/nvim/lua/plugins/snacks.lua
@@ -1,0 +1,14 @@
+return {
+  {
+    "folke/snacks.nvim",
+    opts = {
+      picker = {
+        sources = {
+          files = {
+            hidden = true,
+          },
+        },
+      },
+    },
+  },
+}

--- a/scripts/dev
+++ b/scripts/dev
@@ -60,6 +60,20 @@ pick_project() {
   printf '%s\n' "$projects" | fzf --prompt='Project > ' --height=50% --layout=reverse --border
 }
 
+reload_nvim() {
+  local session="$1"
+  local pane="${session}:1.1"
+  local pane_cmd
+  pane_cmd="$(tmux display-message -t "$pane" -p '#{pane_current_command}' 2>/dev/null || true)"
+  if [[ "$pane_cmd" == "nvim" || "$pane_cmd" == "vim" ]]; then
+    local project
+    project="$(tmux display-message -t "$pane" -p '#{pane_current_path}')"
+    tmux send-keys -t "$pane" Escape ":silent! wa | qa!" C-m
+    sleep 0.5
+    tmux send-keys -t "$pane" "nvim" C-m
+  fi
+}
+
 apply_settings() {
   local session="$1"
   tmux source-file ~/.config/tmux/tmux.conf
@@ -110,6 +124,7 @@ if [[ "${1:-}" == "--refresh" ]]; then
   fi
   session="$(tmux display-message -p '#S')"
   apply_settings "$session"
+  reload_nvim "$session"
   tmux display-message "Settings refreshed"
   exit 0
 fi


### PR DESCRIPTION
## Summary
- Configure Snacks picker to show hidden files/folders (dotfiles) in the file finder via `hidden = true`
- Add `reload_nvim` to `dev --refresh` — saves all buffers, quits nvim, and restarts it so plugin/config changes take effect immediately

## Test plan
- [ ] Open nvim, press `<F6>` or `<leader>ff` — hidden files (`.github/`, `.editorconfig`, etc.) should appear
- [ ] Run `dev --refresh` inside a tmux session — nvim should save, quit, and restart cleanly
- [ ] Run `dev --refresh` when nvim is NOT in pane 1.1 — should skip nvim reload gracefully