### PR TITLE
Fix shell bootstrap theme install and dev launcher behavior

### DIFF
--- a/config/zsh/zshrc
+++ b/config/zsh/zshrc
@@ -50,10 +50,10 @@ alias lg='lazygit'
 alias tl='tmux ls'
 alias ta='tmux attach -t'
 alias tk='tmux ls -F "#{session_name}" | fzf --prompt="Kill session > " --height=50% --layout=reverse --border | xargs -I{} tmux kill-session -t {}'
-alias dev='~/.flatherskevin/local/scripts/dev'
-alias cheat='~/.flatherskevin/local/scripts/cheat'
+alias dev='$HOME/.local/bin/dev'
+alias cheat='$HOME/.local/bin/cheat'
 alias keys='cheat'
-alias leaders='~/.flatherskevin/local/scripts/leaders'
+alias leaders='$HOME/.local/bin/leaders'
 
 workon() {
   dev "$@"

--- a/scripts/dev
+++ b/scripts/dev
@@ -14,6 +14,9 @@ usage() {
 Usage:
   dev                Open the current Git repo, or pick a project directory
   dev /path/to/dir   Open or resume a tmux session for that directory
+  dev --list-session List tmux sessions managed by dev/tmux
+  dev --remove-session [name]
+                     Remove a tmux session by name, or pick one interactively
   dev --refresh      Re-apply layout and settings to the current tmux session
   dev --restart      Kill current session and start a fresh one for the same project
   dev --resume       Reopen all tmux sessions as Kitty tabs
@@ -65,6 +68,22 @@ pick_project() {
 
 current_git_project() {
   git rev-parse --show-toplevel 2>/dev/null || true
+}
+
+list_sessions() {
+  tmux list-sessions -F '#{session_name}' 2>/dev/null || true
+}
+
+pick_session() {
+  local sessions
+  sessions="$(list_sessions)"
+
+  if [[ -z "$sessions" ]]; then
+    printf 'No tmux sessions found\n' >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$sessions" | fzf --prompt='Session > ' --height=50% --layout=reverse --border
 }
 
 reload_nvim() {
@@ -149,8 +168,31 @@ if [[ "${1:-}" == "--workspace" ]]; then
   exit 0
 fi
 
+if [[ "${1:-}" == "--list-session" ]]; then
+  sessions="$(list_sessions)"
+  if [[ -z "$sessions" ]]; then
+    printf 'No tmux sessions found\n' >&2
+    exit 1
+  fi
+  printf '%s\n' "$sessions"
+  exit 0
+fi
+
+if [[ "${1:-}" == "--remove-session" ]]; then
+  session_to_remove="${2:-}"
+  if [[ -z "$session_to_remove" ]]; then
+    session_to_remove="$(pick_session)"
+  fi
+  if [[ -z "$session_to_remove" ]]; then
+    exit 0
+  fi
+  tmux kill-session -t "$session_to_remove"
+  printf 'Removed tmux session: %s\n' "$session_to_remove"
+  exit 0
+fi
+
 if [[ "${1:-}" == "--resume" ]]; then
-  sessions="$(tmux list-sessions -F '#{session_name}' 2>/dev/null)"
+  sessions="$(list_sessions)"
   if [[ -z "$sessions" ]]; then
     printf 'No tmux sessions to resume\n' >&2
     exit 1

--- a/scripts/dev
+++ b/scripts/dev
@@ -12,7 +12,7 @@ done
 usage() {
   cat <<'EOF'
 Usage:
-  dev                Pick a project directory and open or resume a tmux session
+  dev                Open the current Git repo, or pick a project directory
   dev /path/to/dir   Open or resume a tmux session for that directory
   dev --refresh      Re-apply layout and settings to the current tmux session
   dev --restart      Kill current session and start a fresh one for the same project
@@ -28,6 +28,7 @@ sanitize_session_name() {
 
 list_roots() {
   local candidates=(
+    "$PWD"
     "$HOME/code"
     "$HOME/codebase"
     "$HOME/dev"
@@ -60,6 +61,10 @@ pick_project() {
   fi
 
   printf '%s\n' "$projects" | fzf --prompt='Project > ' --height=50% --layout=reverse --border
+}
+
+current_git_project() {
+  git rev-parse --show-toplevel 2>/dev/null || true
 }
 
 reload_nvim() {
@@ -176,7 +181,10 @@ if [[ -n "${1:-}" ]]; then
     exit 1
   fi
 else
-  project="$(pick_project)"
+  project="$(current_git_project)"
+  if [[ -z "$project" ]]; then
+    project="$(pick_project)"
+  fi
 fi
 
 if [[ -z "$project" ]]; then

--- a/scripts/link-configs.sh
+++ b/scripts/link-configs.sh
@@ -8,14 +8,16 @@ source "${SCRIPT_DIR}/../bootstrap/common.sh"
 
 ensure_dir "${HOME}/.config"
 ensure_dir "${HOME}/.local/bin"
+ensure_dir "${HOME}/.oh-my-zsh/custom/themes"
 
 link_path "${REPO_ROOT}/config/nvim" "${HOME}/.config/nvim"
 link_path "${REPO_ROOT}/config/kitty/kitty.conf" "${HOME}/.config/kitty/kitty.conf"
 link_path "${REPO_ROOT}/config/tmux/tmux.conf" "${HOME}/.config/tmux/tmux.conf"
 link_path "${REPO_ROOT}/config/zsh/zshrc" "${HOME}/.config/zsh/zshrc"
+link_path "${REPO_ROOT}/flatherskevin.zsh-theme" "${HOME}/.oh-my-zsh/custom/themes/flatherskevin.zsh-theme"
 
 link_path "${REPO_ROOT}/scripts/dev" "${HOME}/.local/bin/dev"
 link_path "${REPO_ROOT}/scripts/cheat" "${HOME}/.local/bin/cheat"
+link_path "${REPO_ROOT}/scripts/leaders" "${HOME}/.local/bin/leaders"
 
 append_line_once "${HOME}/.zshrc" '[[ -f "$HOME/.config/zsh/zshrc" ]] && source "$HOME/.config/zsh/zshrc"'
-


### PR DESCRIPTION
 ## Summary

  Fix a few setup issues in the local environment bootstrap and launcher flow:

  - install/link the custom `flatherskevin` Oh My Zsh theme during config linking
  - stop hardcoding `~/.flatherskevin/local` for `dev`, `cheat`, and `leaders`
  - use `~/.local/bin` for those commands instead
  - add `dev --list-session` and `dev --remove-session` for tmux session management
  - make `dev` open the current Git repo when run inside one, otherwise fall back to the picker

Picker still works if you run it in a regular file directory

<img width="501" height="388" alt="image" src="https://github.com/user-attachments/assets/d063d7ae-cc15-48e7-9d0e-17f6983c0b73" />

But run dev inside a dir with a .git it will then just open it 

<img width="1347" height="644" alt="image" src="https://github.com/user-attachments/assets/ad89bc4f-12cc-4143-b93d-0c8429e4dc01" />

 ## Summary

  Tighten up the local shell/bootstrap flow and improve `dev` session handling.

  ### Shell/bootstrap fixes

  - install/link the custom `flatherskevin` Oh My Zsh theme during config linking
  - stop hardcoding `~/.flatherskevin/local` for `dev`, `cheat`, and `leaders`
  - use `~/.local/bin` for those commands instead

  ### `dev` improvements

  - when `dev` is run inside a Git repo, open that repo directly instead of showing child directories
  - keep the directory picker fallback when not inside a Git repo
  - add `dev --list-session` to list current tmux sessions
  - add `dev --remove-session [name]` to remove a tmux session directly or pick one interactively

  ## Why

  This fixes a few rough edges in the bootstrap and daily workflow:

  - `source ~/.zshrc` could fail because the configured theme was not installed
  - `dev` could break when running from a checkout that was not located at `~/.flatherskevin/local`
  - running `dev` inside a repo could show subdirectories instead of opening the repo itself
  - session cleanup for `dev --resume` required dropping down to raw `tmux` commands

  ## Testing

  - reran config linking and verified the custom theme can be loaded
  - verified the shell aliases now resolve through `~/.local/bin`
  - verified `dev` now prefers the current Git repo and otherwise falls back to the picker
  - verified tmux sessions can be listed and removed through the new `dev` commands
