### PR TITLE
Fix markdown-preview build to use yarn via npx

### DIFF
--- a/config/nvim/lua/plugins/editor.lua
+++ b/config/nvim/lua/plugins/editor.lua
@@ -97,7 +97,7 @@ return {
   {
     "iamcco/markdown-preview.nvim",
     ft = { "markdown" },
-    build = "cd app && npm install",
+    build = "cd app && npx --yes yarn install",
   },
   {
     "MagicDuck/grug-far.nvim",


### PR DESCRIPTION
## Summary
- Switch markdown-preview.nvim build from `npm install` to `npx --yes yarn install`
- `npm install` creates `package-lock.json` and modifies `yarn.lock`, which makes lazy.nvim see the plugin directory as dirty and refuse to update
- `npx yarn` respects the existing `yarn.lock` without creating extra files

## Test plan
- [ ] Run `:Lazy sync` in nvim — markdown-preview.nvim shows no "local changes" warning
- [ ] Open a `.md` file and run `:MarkdownPreview` — browser preview opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)