### PR TITLE
Fix Escape in tmux copy mode to stay scrolled

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -35,10 +35,9 @@ bind -T copy-mode-vi TripleClick1Pane select-pane \; send-keys -X select-line
 bind -T copy-mode-vi v send-keys -X begin-selection
 bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 
-# Escape clears selection but stays in copy mode (overrides tmux default which exits)
-bind -T copy-mode-vi Escape send-keys -X clear-selection
-# q exits copy mode and jumps back to the bottom
-bind -T copy-mode-vi q send-keys -X cancel
+# Escape exits copy mode (tmux default)
+# q clears selection but stays in copy mode so you can keep reading
+bind -T copy-mode-vi q send-keys -X clear-selection
 set -g focus-events on
 set -g escape-time 0
 set -g repeat-time 300

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -35,7 +35,9 @@ bind -T copy-mode-vi TripleClick1Pane select-pane \; send-keys -X select-line
 bind -T copy-mode-vi v send-keys -X begin-selection
 bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 
-# q to exit copy mode; Escape just clears selection (default) so you stay scrolled
+# Escape clears selection but stays in copy mode (overrides tmux default which exits)
+bind -T copy-mode-vi Escape send-keys -X clear-selection
+# q exits copy mode and jumps back to the bottom
 bind -T copy-mode-vi q send-keys -X cancel
 set -g focus-events on
 set -g escape-time 0


### PR DESCRIPTION
## Summary
- Explicitly binds Escape to `clear-selection` in copy-mode-vi to override tmux's built-in default (which is `cancel`, same as q)
- Previous PR removed the binding expecting the default to differ — it doesn't, both Escape and q defaulted to exiting copy mode

## Test plan
- [ ] `prefix r` to reload tmux config
- [ ] Scroll up in a tmux pane to enter copy mode
- [ ] Press Escape — should clear any selection but stay scrolled up
- [ ] Press q — should exit copy mode and jump to the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)