### PR TITLE
Explicitly bind Escape to cancel in tmux copy mode

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -35,7 +35,8 @@ bind -T copy-mode-vi TripleClick1Pane select-pane \; send-keys -X select-line
 bind -T copy-mode-vi v send-keys -X begin-selection
 bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 
-# Escape exits copy mode (tmux default)
+# Escape exits copy mode
+bind -T copy-mode-vi Escape send-keys -X cancel
 # q clears selection but stays in copy mode so you can keep reading
 bind -T copy-mode-vi q send-keys -X clear-selection
 set -g focus-events on


### PR DESCRIPTION
## Summary
- Adds explicit `bind -T copy-mode-vi Escape send-keys -X cancel` — relying on the tmux default doesn't work after a config reload since tmux doesn't restore built-in defaults for previously overridden keys

## Test plan
- [ ] `Ctrl-a r` to reload tmux config
- [ ] Scroll up to enter copy mode
- [ ] Press Escape — should exit copy mode and jump to bottom
- [ ] Scroll up again, press q — should clear selection and stay scrolled

🤖 Generated with [Claude Code](https://claude.com/claude-code)