### PR TITLE
Branch new gitwadd worktrees from fresh origin/main

### DIFF
--- a/config/zsh/zshrc
+++ b/config/zsh/zshrc
@@ -102,7 +102,8 @@ _gitwadd() {
   if git -C "$repo_path" show-ref --verify --quiet "refs/heads/$branch"; then
     git -C "$repo_path" worktree add "$worktree_path" "$branch"
   else
-    git -C "$repo_path" worktree add -b "$branch" "$worktree_path"
+    git -C "$repo_path" fetch origin main && \
+      git -C "$repo_path" worktree add -b "$branch" "$worktree_path" origin/main
   fi
 }
 


### PR DESCRIPTION
## Summary
- `_gitwadd` previously cut a brand-new branch from whatever HEAD was checked out in the source repo, so a worktree spun up mid-coding inherited the in-progress branch's tip.
- Now fetches `origin/main` and bases the new branch on `origin/main`, giving a clean, up-to-date starting point.
- The fetch + `worktree add` are both non-disruptive: HEAD, index, and working tree of the source repo are untouched.

## Notes
- `main` is hardcoded — repos using `master` as the default branch are not currently handled. Could swap for `git symbolic-ref --short refs/remotes/origin/HEAD` if that becomes a need.
- Existing-branch path (when `$branch` already exists locally) is unchanged.

## Test plan
- [ ] `source ~/.zshrc`
- [ ] In `~/Klaviyo/Repos/k-repo` with a dirty/in-progress branch checked out, run `gitwaddkrepo scratch-test` and confirm:
  - [ ] the source repo's HEAD/working tree are unchanged
  - [ ] the new worktree's branch is based on the latest `origin/main`
- [ ] `./scripts/lint-shell.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)