### PR TITLE
Add dev more: companion terminal tabs for a workstream

### DIFF
--- a/docs/ai/USAGE.md
+++ b/docs/ai/USAGE.md
@@ -42,6 +42,7 @@ Primary workflow commands:
 - `dev /path/to/project`
 - `dev session list [--filter TEXT]`
 - `dev session kill -s NAME...`
+- `dev more [--session NAME]`
 - `dev --refresh`
 - `dev --restart`
 - `dev --resume`
@@ -71,6 +72,11 @@ named repos do not collide.
 
 Kitty tab titles are expected to surface the active tmux session name. tmux
 status remains off.
+
+For more terminal room in a workstream, `dev more` opens another Kitty tab of equally
+sized terminals backed by a companion session named `<session>+<n>`. Companions persist
+when their tab is closed and can be resumed from the `dev more` picker; killing the
+parent session with `dev session kill` also removes its companions.
 
 ## AI Tooling
 

--- a/docs/superpowers/plans/2026-06-30-dev-more.md
+++ b/docs/superpowers/plans/2026-06-30-dev-more.md
@@ -273,14 +273,20 @@ if command -v tmux >/dev/null 2>&1; then
   pane_count="$(tmux list-panes -t "${test_companion}:1" 2>/dev/null | wc -l | tr -d ' ')"
   check "create_companion_session pane count" "4" "$pane_count"
 
-  layout_name="$(tmux display-message -p -t "${test_companion}:1" '#{window_layout}' | cut -d, -f1)"
-  # tmux reports tiled windows' layout string with a leading checksum, so assert via
-  # the pane geometry instead: 4 equal tiles means 2 distinct widths or heights at most.
-  distinct_dims="$(tmux list-panes -t "${test_companion}:1" -F '#{pane_width}x#{pane_height}' | sort -u | wc -l | tr -d ' ')"
-  check "create_companion_session tiled (<=2 distinct pane sizes)" "1" "$([[ "$distinct_dims" -le 2 ]] && echo 1 || echo 0)"
+  # A 4-pane `tiled` layout is always a 2x2 grid (tmux uses ceil(sqrt(n)) rows),
+  # so it has exactly two distinct column offsets and two distinct row offsets.
+  # A wrong layout (e.g. main-vertical = 1 left + 3 stacked) would give 3 distinct
+  # rows, so this structurally confirms tiling without depending on tmux's
+  # layout-checksum string.
+  distinct_left="$(tmux list-panes -t "${test_companion}:1" -F '#{pane_left}' | sort -u | wc -l | tr -d ' ')"
+  distinct_top="$(tmux list-panes -t "${test_companion}:1" -F '#{pane_top}' | sort -u | wc -l | tr -d ' ')"
+  check "create_companion_session tiled 2x2 (2 columns)" "2" "$distinct_left"
+  check "create_companion_session tiled 2x2 (2 rows)" "2" "$distinct_top"
 
+  # mktemp -d returns a /var/folders/... path that tmux reports through its
+  # /private symlink, so normalize both sides with `pwd -P` before comparing.
   first_pane_path="$(tmux display-message -p -t "${test_companion}:1.1" '#{pane_current_path}')"
-  check "create_companion_session cwd" "$test_dir" "$first_pane_path"
+  check "create_companion_session cwd" "$(cd "$test_dir" && pwd -P)" "$(cd "$first_pane_path" && pwd -P)"
 
   tmux kill-session -t "$test_companion" 2>/dev/null || true
   rm -rf "$test_dir"
@@ -290,7 +296,7 @@ else
 fi
 ```
 
-Note on the layout assertion: a clean `tiled` 2x2 grid yields panes of at most two distinct `WxH` sizes (equal columns/rows can differ by one cell). `<= 2 distinct sizes` confirms tiling without depending on tmux's layout checksum string. `mktemp -d` returns a path under `/var/folders/...` on macOS; tmux may report it through a `/private` symlink, so if this `cwd` check proves flaky in practice, compare with `realpath`. Implementer: run it; if `cwd` mismatches due to `/private`, change both sides to `"$(cd "$test_dir" && pwd -P)"`.
+Note on the layout assertion: do NOT assert on distinct `WxH` pane sizes. A 4-pane tiled 2x2 grid has up to four distinct `WxH` sizes, because each axis splits independently around a 1-cell separator. Assert the grid structure instead (2 distinct `pane_left` offsets and 2 distinct `pane_top` offsets), which is exact for 4 tiled panes and fails for non-grid layouts. Do not capture an unused `window_layout` variable (shellcheck SC2034). The `cwd` assertion normalizes both paths with `pwd -P` because macOS `mktemp -d` returns a `/var/folders/...` path that tmux reports through its `/private` symlink.
 
 - [ ] **Step 2: Run the test to verify it fails**
 

--- a/docs/superpowers/plans/2026-06-30-dev-more.md
+++ b/docs/superpowers/plans/2026-06-30-dev-more.md
@@ -1,0 +1,776 @@
+# `dev more` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `dev more` subcommand that opens a new kitty tab of equally proportioned terminal panes tied to an existing workstream, backed by its own namespaced tmux "companion" session.
+
+**Architecture:** Companions are real tmux sessions named `<parent>+<n>`. `dev more` resolves the parent (from `--session` or the current tmux session), resolves the parent's project directory via `#{session_path}`, and either creates the next companion (lowest free slot) or opens an fzf picker to resume a detached one. Each companion is built detached with `--count` tiled panes, then attached in a fresh kitty tab. Pure helpers are factored out and unit-tested; the script gets a `BASH_SOURCE` guard so it can be sourced by the test.
+
+**Tech Stack:** Bash (`scripts/dev`, `set -euo pipefail`), tmux 3.6a, kitty remote control, fzf. Lint via `shellcheck`. No unit-test framework exists; tests are plain-bash assertions matching `scripts/smoke-test-cli.sh`.
+
+## Global Constraints
+
+- Target shell: `bash` with `set -euo pipefail` (matches `scripts/dev:3`). All new code must run under `set -u` (use `${var:-}` for possibly-unset vars).
+- Maintain bash 3.2 compatibility (macOS system bash). The existing script uses only 3.2-safe constructs. Do NOT introduce associative arrays (`declare -A`/`local -A`), `mapfile`/`readarray`, `${var,,}`, or `&>` redirection. Indexed arrays (`local -a`), C-style `for (( ))`, `[[ =~ ]]`, and `${var##...}` are fine (already used in the file).
+- `scripts/test-dev-more.sh` sources `scripts/dev`, which runs the `fd`/`fzf`/`tmux` dependency check at the top (`scripts/dev:5-10`). The test therefore requires those tools present (true in the dev environment). CI does not run this test; it is part of local/manual verification.
+- All edited shell files MUST pass `shellcheck` via `./scripts/lint-shell.sh` with zero findings. Prefer fixing over suppressing; if a suppression is unavoidable, scope it to a single line with `# shellcheck disable=SCxxxx`.
+- tmux session names MUST NOT contain `.` or `:`. The companion delimiter is `+` (e.g. `repo-56e811+1`).
+- Treat `dev` as a workflow entrypoint, not a generic subcommand framework (per `docs/ai/DEVELOPMENT.md`). Keep behavior readable and deterministic.
+- Documentation must stay in sync: any user-facing command change updates `usage()` in `scripts/dev`, `scripts/cheat`, and `docs/ai/USAGE.md`. No em-dashes in committed prose.
+- Default pane count is `4`. The layout is tmux `tiled`.
+- Verification suite for `dev` changes (from `docs/ai/DEVELOPMENT.md`): `./scripts/lint-shell.sh`, `./scripts/validate-doc-links.py`, `./scripts/smoke-test-cli.sh`, `git diff --check`, plus the new `./scripts/test-dev-more.sh`.
+- Reference line numbers below are against `scripts/dev` at branch `add-dev-more-companion-tabs` base (origin/main). Re-confirm exact lines before editing, since earlier tasks shift them.
+
+---
+
+## File Structure
+
+- `scripts/dev` (modify): add a `BASH_SOURCE` guard before the dispatch block; add companion helper functions near the existing helpers; add `dev_more_command`; wire a `more` branch into the dispatch block; extend `session_kill_command` and `session_list_command`; update `usage()`.
+- `scripts/test-dev-more.sh` (create): plain-bash test runner. Sources `scripts/dev`, asserts pure-helper behavior, and runs a tmux-backed layout check guarded by `command -v tmux`.
+- `scripts/cheat` (modify): add a `dev more` cheat entry.
+- `docs/ai/USAGE.md` (modify): add `dev more` to the Day-To-Day Commands list and a short note in the Session Model section.
+- `docs/appendix/cheatsheet.md` (modify, only if it lists dev commands): add `dev more`.
+
+---
+
+## Task 1: Make `scripts/dev` sourceable (BASH_SOURCE guard)
+
+Refactor-only task. Adds a guard so the test can `source scripts/dev` to load its functions without executing the dispatch logic. No behavior change when the script is run directly.
+
+**Files:**
+- Modify: `scripts/dev` (insert guard immediately before the first dispatch `if`, currently `scripts/dev:310`)
+- Test: manual verification commands below
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: sourcing `scripts/dev` from bash loads all functions and returns 0 without running dispatch. Executing `scripts/dev ...` directly is unchanged.
+
+- [ ] **Step 1: Locate the dispatch block start**
+
+Run: `grep -n 'if \[\[ "\${1:-}" == "-h"' scripts/dev`
+Expected: one line near the bottom (the first dispatch `if`, around line 310). This is where the guard goes (immediately before it).
+
+- [ ] **Step 2: Insert the guard**
+
+Insert these lines immediately BEFORE the line `if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then` (the first dispatch block):
+
+```bash
+# When this file is sourced (e.g. by scripts/test-dev-more.sh) rather than
+# executed, stop here so only the function definitions above are loaded.
+if [[ "${BASH_SOURCE[0]:-}" != "${0}" ]]; then
+  return 0
+fi
+
+```
+
+- [ ] **Step 3: Verify direct execution is unchanged**
+
+Run: `./scripts/dev --help`
+Expected: prints the usage text (the `usage()` output) and exits 0.
+
+- [ ] **Step 4: Verify sourcing loads functions without dispatching**
+
+Run: `bash -c 'source ./scripts/dev && type session_name_for_project >/dev/null && echo SOURCED_OK'`
+Expected: prints `SOURCED_OK` and nothing else (no project picker, no tmux attach).
+
+- [ ] **Step 5: Lint and smoke**
+
+Run: `./scripts/lint-shell.sh && ./scripts/smoke-test-cli.sh`
+Expected: shellcheck reports nothing; smoke prints `[smoke] ./scripts/dev --help` etc. and exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/dev
+git commit -m "Make dev sourceable via BASH_SOURCE guard for tests"
+```
+
+---
+
+## Task 2: Pure companion helpers + unit tests
+
+Add the pure string/slot helpers and a test runner that sources `scripts/dev` and asserts them. TDD: write the test runner first, watch it fail, then implement.
+
+**Files:**
+- Create: `scripts/test-dev-more.sh`
+- Modify: `scripts/dev` (add helper functions next to `session_name_for_project`, after `scripts/dev:42`)
+
+**Interfaces:**
+- Produces (exact signatures later tasks rely on):
+  - `companion_name PARENT N` -> prints `PARENT+N`.
+  - `is_companion NAME` -> exit 0 if NAME ends in `+<digits>`, else exit 1.
+  - `parent_of_session NAME` -> prints NAME with a trailing `+<digits>` removed (unchanged if none).
+  - `companions_of PARENT` -> prints, one per line, the names from `list_sessions` that match `^PARENT+<digits>$`. Depends on the existing `list_sessions` (`scripts/dev:95`), so tests stub `list_sessions`.
+  - `next_companion_slot PARENT` -> prints the smallest integer `n >= 1` such that `PARENT+n` is not in `companions_of PARENT`.
+
+- [ ] **Step 1: Write the failing test runner**
+
+Create `scripts/test-dev-more.sh`:
+
+```bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Resolve repo root from this script's location so the test can be run from anywhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/dev
+source "${SCRIPT_DIR}/dev"
+
+tests_run=0
+tests_failed=0
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  tests_run=$((tests_run + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    printf '[pass] %s\n' "$label"
+  else
+    tests_failed=$((tests_failed + 1))
+    printf '[FAIL] %s\n  expected: %q\n  actual:   %q\n' "$label" "$expected" "$actual"
+  fi
+}
+
+check_status() {
+  local label="$1" expected_status="$2"
+  shift 2
+  local actual_status=0
+  "$@" >/dev/null 2>&1 || actual_status=$?
+  tests_run=$((tests_run + 1))
+  if [[ "$expected_status" -eq "$actual_status" ]]; then
+    printf '[pass] %s\n' "$label"
+  else
+    tests_failed=$((tests_failed + 1))
+    printf '[FAIL] %s\n  expected status: %s\n  actual status:   %s\n' "$label" "$expected_status" "$actual_status"
+  fi
+}
+
+# --- companion_name ---
+check "companion_name basic" "repo-56e811+1" "$(companion_name "repo-56e811" 1)"
+check "companion_name two digit" "repo-56e811+12" "$(companion_name "repo-56e811" 12)"
+
+# --- is_companion ---
+check_status "is_companion true" 0 is_companion "repo-56e811+2"
+check_status "is_companion false (parent)" 1 is_companion "repo-56e811"
+check_status "is_companion false (plus no digit)" 1 is_companion "repo-56e811+x"
+
+# --- parent_of_session ---
+check "parent_of_session strips suffix" "repo-56e811" "$(parent_of_session "repo-56e811+3")"
+check "parent_of_session passthrough" "repo-56e811" "$(parent_of_session "repo-56e811")"
+check "parent_of_session two-digit suffix" "repo-56e811" "$(parent_of_session "repo-56e811+10")"
+
+# --- companions_of + next_companion_slot (stub list_sessions) ---
+list_sessions() {
+  printf '%s\n' "repo-56e811" "repo-56e811+1" "repo-56e811+3" "other-abc123" "other-abc123+1"
+}
+check "companions_of filters to parent" "repo-56e811+1
+repo-56e811+3" "$(companions_of "repo-56e811")"
+check "next_companion_slot fills gap" "2" "$(next_companion_slot "repo-56e811")"
+check "next_companion_slot first free" "2" "$(next_companion_slot "other-abc123")"
+
+list_sessions() { printf '%s\n' "repo-56e811"; }
+check "next_companion_slot none used" "1" "$(next_companion_slot "repo-56e811")"
+
+printf '\n%d run, %d failed\n' "$tests_run" "$tests_failed"
+[[ "$tests_failed" -eq 0 ]]
+```
+
+Then: `chmod +x scripts/test-dev-more.sh`
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./scripts/test-dev-more.sh`
+Expected: FAIL. Because the helpers do not exist yet, sourcing succeeds but the first `companion_name` call errors with `command not found` (script exits non-zero under `set -e`).
+
+- [ ] **Step 3: Implement the helpers**
+
+In `scripts/dev`, immediately AFTER `session_name_for_project` (after its closing `}` at `scripts/dev:42`), add:
+
+```bash
+companion_name() {
+  local parent="$1" slot="$2"
+  printf '%s+%s\n' "$parent" "$slot"
+}
+
+is_companion() {
+  [[ "$1" =~ \+[0-9]+$ ]]
+}
+
+parent_of_session() {
+  local name="$1"
+  printf '%s\n' "${name%+[0-9]*}"
+}
+
+companions_of() {
+  local parent="$1"
+  list_sessions | grep -E "^${parent}\+[0-9]+$" || true
+}
+
+next_companion_slot() {
+  local parent="$1"
+  local name slots n
+  # Collect used slot numbers (no associative arrays; macOS ships bash 3.2).
+  slots="$(
+    while IFS= read -r name; do
+      [[ -z "$name" ]] && continue
+      printf '%s\n' "${name##*+}"
+    done < <(companions_of "$parent") | sort -n
+  )"
+  n=1
+  while printf '%s\n' "$slots" | grep -qx "$n"; do
+    n=$((n + 1))
+  done
+  printf '%s\n' "$n"
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./scripts/test-dev-more.sh`
+Expected: every line `[pass] ...`, final line `12 run, 0 failed`, exit 0.
+
+- [ ] **Step 5: Lint**
+
+Run: `./scripts/lint-shell.sh`
+Expected: shellcheck clean. Note: `scripts/test-dev-more.sh` is matched by the `find ... -name '*.sh'` in `scripts/lint-shell.sh`, so it is linted automatically.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/dev scripts/test-dev-more.sh
+git commit -m "Add companion-name and slot helpers with unit tests"
+```
+
+---
+
+## Task 3: Build a companion tmux session (`create_companion_session`)
+
+Add the function that builds a detached companion session with N tiled panes, plus a tmux-backed test (skipped when tmux is unavailable).
+
+**Files:**
+- Modify: `scripts/dev` (add `create_companion_session` after the existing `create_session`, after `scripts/dev:150`)
+- Modify: `scripts/test-dev-more.sh` (append a tmux-backed check)
+
+**Interfaces:**
+- Consumes: nothing from other new tasks.
+- Produces: `create_companion_session NAME PROJECT COUNT` -> creates a detached tmux session NAME with COUNT panes in window 1, working dir PROJECT, layout `tiled`, a `window-resized` hook re-applying `tiled`, and focus on pane `NAME:1.1`. Assumes NAME does not already exist (caller guarantees this via `next_companion_slot`).
+
+- [ ] **Step 1: Write the failing tmux-backed test**
+
+Append to `scripts/test-dev-more.sh` BEFORE the final summary block (`printf '\n%d run ...`):
+
+```bash
+# --- create_companion_session (tmux-backed; skipped without tmux) ---
+if command -v tmux >/dev/null 2>&1; then
+  test_parent="devmoretest-$$"
+  test_companion="${test_parent}+1"
+  test_dir="$(mktemp -d)"
+  # Ensure cleanup even on failure.
+  trap 'tmux kill-session -t "$test_companion" 2>/dev/null || true; rm -rf "$test_dir"' EXIT
+
+  create_companion_session "$test_companion" "$test_dir" 4
+
+  pane_count="$(tmux list-panes -t "${test_companion}:1" 2>/dev/null | wc -l | tr -d ' ')"
+  check "create_companion_session pane count" "4" "$pane_count"
+
+  layout_name="$(tmux display-message -p -t "${test_companion}:1" '#{window_layout}' | cut -d, -f1)"
+  # tmux reports tiled windows' layout string with a leading checksum, so assert via
+  # the pane geometry instead: 4 equal tiles means 2 distinct widths or heights at most.
+  distinct_dims="$(tmux list-panes -t "${test_companion}:1" -F '#{pane_width}x#{pane_height}' | sort -u | wc -l | tr -d ' ')"
+  check "create_companion_session tiled (<=2 distinct pane sizes)" "1" "$([[ "$distinct_dims" -le 2 ]] && echo 1 || echo 0)"
+
+  first_pane_path="$(tmux display-message -p -t "${test_companion}:1.1" '#{pane_current_path}')"
+  check "create_companion_session cwd" "$test_dir" "$first_pane_path"
+
+  tmux kill-session -t "$test_companion" 2>/dev/null || true
+  rm -rf "$test_dir"
+  trap - EXIT
+else
+  printf '[skip] create_companion_session (tmux not available)\n'
+fi
+```
+
+Note on the layout assertion: a clean `tiled` 2x2 grid yields panes of at most two distinct `WxH` sizes (equal columns/rows can differ by one cell). `<= 2 distinct sizes` confirms tiling without depending on tmux's layout checksum string. `mktemp -d` returns a path under `/var/folders/...` on macOS; tmux may report it through a `/private` symlink, so if this `cwd` check proves flaky in practice, compare with `realpath`. Implementer: run it; if `cwd` mismatches due to `/private`, change both sides to `"$(cd "$test_dir" && pwd -P)"`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./scripts/test-dev-more.sh`
+Expected: FAIL at `create_companion_session` (function not defined, `command not found` under `set -e`) when tmux is present. If tmux is absent it prints `[skip]` and the earlier tests still pass; in that case implement and verify on a machine with tmux.
+
+- [ ] **Step 3: Implement `create_companion_session`**
+
+In `scripts/dev`, immediately AFTER `create_session` (after its closing `}` at `scripts/dev:150`), add:
+
+```bash
+create_companion_session() {
+  local session="$1" project="$2" count="$3"
+  local i
+  tmux new-session -d -s "$session" -c "$project"
+  for ((i = 1; i < count; i++)); do
+    tmux split-window -c "$project" -t "${session}:1"
+    tmux select-layout -t "${session}:1" tiled
+  done
+  tmux source-file ~/.config/tmux/tmux.conf
+  tmux select-layout -t "${session}:1" tiled
+  tmux set-hook -t "$session" window-resized "select-layout tiled"
+  tmux select-pane -t "${session}:1.1"
+}
+```
+
+Note: re-applying `select-layout tiled` inside the loop keeps room for the next split so panes never get too small to divide; the final `select-layout tiled` balances the grid.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./scripts/test-dev-more.sh`
+Expected: the three `create_companion_session ...` checks pass (or `[skip]` without tmux), final line `0 failed`, exit 0.
+
+- [ ] **Step 5: Lint**
+
+Run: `./scripts/lint-shell.sh`
+Expected: shellcheck clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/dev scripts/test-dev-more.sh
+git commit -m "Add create_companion_session tiled-layout builder with tmux test"
+```
+
+---
+
+## Task 4: The `dev more` command + picker + dispatch wiring
+
+Add the picker helpers and `dev_more_command`, then wire a `more` branch into the dispatch block. This is the orchestration task; the pieces it consumes (`companion_name`, `next_companion_slot`, `parent_of_session`, `companions_of`, `create_companion_session`) all exist from Tasks 2-3.
+
+**Files:**
+- Modify: `scripts/dev` (add `detached_companions`, `parse_picker_selection`, `pick_companion_action`, `open_companion_tab`, `dev_more_command` after `set_current_tab_title` at `scripts/dev:162`; add the `more` dispatch branch after the `session` block, currently ending at `scripts/dev:332`; update `usage()` at `scripts/dev:12-24`)
+- Modify: `scripts/test-dev-more.sh` (append `parse_picker_selection` checks)
+
+**Interfaces:**
+- Consumes: `companion_name`, `next_companion_slot`, `parent_of_session`, `companions_of`, `create_companion_session`, `kitty_remote_available` (`scripts/dev:152`), `list_sessions` (`scripts/dev:95`).
+- Produces:
+  - `detached_companions PARENT` -> prints detached companion names of PARENT, one per line (uses `tmux list-sessions` attached flag).
+  - `parse_picker_selection LINE` -> prints the first whitespace-delimited field of LINE (the selection key: either `NEW` or a session name). Empty input prints nothing.
+  - `dev_more_command [args...]` -> the full subcommand.
+
+- [ ] **Step 1: Write failing `parse_picker_selection` tests**
+
+Append to `scripts/test-dev-more.sh` BEFORE the tmux-backed block:
+
+```bash
+# --- parse_picker_selection (use $'\t' so the tab is unambiguous) ---
+check "parse_picker_selection NEW" "NEW" "$(parse_picker_selection $'NEW\t* New companion (+3)')"
+check "parse_picker_selection name" "repo-56e811+1" "$(parse_picker_selection $'repo-56e811+1\t+1 . 4 panes')"
+check "parse_picker_selection empty" "" "$(parse_picker_selection "")"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `./scripts/test-dev-more.sh`
+Expected: FAIL (`parse_picker_selection: command not found`).
+
+- [ ] **Step 3: Implement the picker helpers and command**
+
+In `scripts/dev`, immediately AFTER `set_current_tab_title` (after its closing `}` at `scripts/dev:162`), add:
+
+```bash
+# Detached companions of PARENT, reusing the tested companions_of helper.
+detached_companions() {
+  local parent="$1" name attached
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    attached="$(tmux display-message -p -t "$name" '#{session_attached}' 2>/dev/null || true)"
+    [[ "$attached" == "0" ]] && printf '%s\n' "$name"
+  done < <(companions_of "$parent")
+}
+
+parse_picker_selection() {
+  local line="$1"
+  printf '%s\n' "${line%%[[:space:]]*}"
+}
+
+# Decides what `dev more` should do. Prints "NEW", the chosen companion name, or
+# nothing (when the picker is cancelled). Falls back to "NEW" when nothing is
+# detached or when fzf is unavailable.
+pick_companion_action() {
+  local parent="$1" next_slot="$2"
+  local detached menu name panes selection
+  detached="$(detached_companions "$parent")"
+
+  if [[ -z "$detached" ]] || ! command -v fzf >/dev/null 2>&1; then
+    printf 'NEW\n'
+    return 0
+  fi
+
+  # Build the fzf menu at function scope (avoids `local` inside a subshell).
+  # Each line is "KEY<TAB>LABEL"; KEY is "NEW" or a session name (never has spaces).
+  menu="$(printf 'NEW\t* New companion (+%s)' "$next_slot")"
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    panes="$(tmux list-panes -t "$name" 2>/dev/null | wc -l | tr -d ' ')"
+    menu+="$(printf '\n%s\t+%s . %s panes' "$name" "${name##*+}" "$panes")"
+  done <<< "$detached"
+
+  selection="$(printf '%s\n' "$menu" | fzf --delimiter='\t' --with-nth=2.. \
+      --prompt='Companion > ' --height=50% --layout=reverse --border \
+      --preview 'sel={1}; if [ "$sel" = NEW ]; then echo "Open a new tab of terminals."; else tmux list-panes -t "$sel" -F "#{pane_index}: #{pane_current_command}  (#{pane_current_path})" 2>/dev/null; fi' \
+      --preview-window='right,45%')" || true
+
+  if [[ -z "$selection" ]]; then
+    # Picker cancelled (Escape).
+    return 0
+  fi
+
+  parse_picker_selection "$selection"
+}
+
+open_companion_tab() {
+  local name="$1"
+  if [[ -n "${KITTY_WINDOW_ID:-}" ]] && kitty_remote_available; then
+    kitty @ launch --type=tab --tab-title "$name" tmux attach-session -t "$name"
+  else
+    printf 'Kitty remote control is unavailable; attach with: tmux attach-session -t %s\n' "$name" >&2
+  fi
+}
+
+dev_more_command() {
+  local parent="" count=4 force_new=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --session)
+        parent="${2:-}"
+        if [[ -z "$parent" ]]; then
+          printf 'Usage: dev more [--session NAME] [--count N] [--new]\n' >&2
+          exit 1
+        fi
+        shift 2
+        ;;
+      --count)
+        count="${2:-}"
+        if [[ ! "$count" =~ ^[0-9]+$ ]] || [[ "$count" -lt 1 ]]; then
+          printf 'dev more: --count must be a positive integer\n' >&2
+          exit 1
+        fi
+        shift 2
+        ;;
+      --new)
+        force_new=1
+        shift
+        ;;
+      -h|--help)
+        cat <<'EOF'
+Usage: dev more [--session NAME] [--count N] [--new]
+
+Open a new Kitty tab of terminals tied to a workstream (a "companion" session).
+
+Options:
+  --session NAME  Parent session id (e.g. repo-56e811). Defaults to the current
+                  tmux session when run inside one.
+  --count N       Number of terminal panes in the new tab (default 4).
+  --new           Skip the resume picker and always create a fresh companion.
+EOF
+        exit 0
+        ;;
+      *)
+        printf 'Unknown option for dev more: %s\n' "$1" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ -z "$parent" ]]; then
+    if [[ -n "${TMUX:-}" ]]; then
+      parent="$(parent_of_session "$(tmux display-message -p '#S')")"
+    else
+      printf 'dev more: provide --session NAME or run inside a tmux session\n' >&2
+      exit 1
+    fi
+  fi
+
+  if ! tmux has-session -t "$parent" 2>/dev/null; then
+    printf 'dev more: no tmux session named: %s\n' "$parent" >&2
+    exit 1
+  fi
+
+  local project
+  project="$(tmux display-message -p -t "$parent" '#{session_path}')"
+  if [[ -z "$project" ]]; then
+    project="$(tmux display-message -p -t "$parent" '#{pane_current_path}')"
+  fi
+
+  local next_slot action target
+  next_slot="$(next_companion_slot "$parent")"
+
+  if [[ "$force_new" -eq 1 ]]; then
+    action="NEW"
+  else
+    action="$(pick_companion_action "$parent" "$next_slot")"
+  fi
+
+  if [[ -z "$action" ]]; then
+    # Picker cancelled.
+    exit 0
+  fi
+
+  if [[ "$action" == "NEW" ]]; then
+    target="$(companion_name "$parent" "$next_slot")"
+    create_companion_session "$target" "$project" "$count"
+  else
+    target="$action"
+  fi
+
+  open_companion_tab "$target"
+}
+```
+
+- [ ] **Step 4: Wire `more` into the dispatch block**
+
+In `scripts/dev`, immediately AFTER the closing `fi` of the `session` dispatch block (currently `scripts/dev:332`, the `fi` that follows `exit 0` of the session branch), add:
+
+```bash
+if [[ "${1:-}" == "more" ]]; then
+  shift
+  dev_more_command "$@"
+  exit 0
+fi
+```
+
+- [ ] **Step 5: Update `usage()`**
+
+In `scripts/dev`, inside the `usage()` heredoc (`scripts/dev:13-23`), add this line immediately after the `dev session kill ...` line:
+
+```
+  dev more [--session NAME]        Open a new Kitty tab of terminals for a workstream
+```
+
+- [ ] **Step 6: Run unit tests and help checks**
+
+Run: `./scripts/test-dev-more.sh`
+Expected: all checks pass including the new `parse_picker_selection` ones; `0 failed`.
+
+Run: `./scripts/dev more --help`
+Expected: prints the `dev more` usage text, exit 0.
+
+Run: `./scripts/dev more --session does-not-exist-xyz`
+Expected: prints `dev more: no tmux session named: does-not-exist-xyz` to stderr, exit 1.
+
+Run: `./scripts/dev more --count 0 --session whatever`
+Expected: prints `dev more: --count must be a positive integer` to stderr, exit 1. (Count is validated before the session check.)
+
+- [ ] **Step 7: Lint and smoke**
+
+Run: `./scripts/lint-shell.sh && ./scripts/smoke-test-cli.sh`
+Expected: shellcheck clean; smoke passes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/dev scripts/test-dev-more.sh
+git commit -m "Add dev more subcommand with resume picker"
+```
+
+---
+
+## Task 5: Cascade kills and group the listing
+
+When a parent session is killed, also kill its companions. When listing sessions, group companions under their parent.
+
+**Files:**
+- Modify: `scripts/dev` (`session_kill_command` at `scripts/dev:199-245`; `session_list_command` at `scripts/dev:164-197`)
+- Modify: `scripts/test-dev-more.sh` (append grouping-sort check)
+
+**Interfaces:**
+- Consumes: `companions_of` (Task 2).
+- Produces: `session_kill_command` kills `<parent>+<n>` companions after killing a parent target (and reports each). `session_list_command` output is sorted so each parent is immediately followed by its companions.
+
+- [ ] **Step 1: Write a failing grouping check**
+
+The grouping is "sort so companions follow their parent." `sort` already does this because a parent name is a proper prefix of its companions and `+` sorts before alphanumerics. Lock it in with a check. Append to `scripts/test-dev-more.sh` BEFORE the tmux-backed block:
+
+```bash
+# --- session listing groups companions under their parent (via sort) ---
+group_sample="$(printf '%s\n' "repo-56e811+2" "other-abc123" "repo-56e811" "repo-56e811+1" | sort)"
+group_expected="other-abc123
+repo-56e811
+repo-56e811+1
+repo-56e811+2"
+check "companion grouping sort order" "$group_expected" "$group_sample"
+```
+
+- [ ] **Step 2: Run to confirm it passes already (documents the invariant)**
+
+Run: `./scripts/test-dev-more.sh`
+Expected: this check passes immediately (it tests `sort`'s behavior, which the implementation will rely on). This is a guard against a future change to the delimiter that would break grouping.
+
+- [ ] **Step 3: Add the kill cascade**
+
+In `scripts/dev`, in `session_kill_command`, replace the kill loop (currently `scripts/dev:234-242`):
+
+```bash
+  for target in "${targets[@]}"; do
+    if tmux has-session -t "$target" 2>/dev/null; then
+      tmux kill-session -t "$target"
+      printf 'Removed tmux session: %s\n' "$target"
+    else
+      printf 'No tmux session named: %s\n' "$target" >&2
+      status=1
+    fi
+  done
+```
+
+with:
+
+```bash
+  for target in "${targets[@]}"; do
+    if tmux has-session -t "$target" 2>/dev/null; then
+      tmux kill-session -t "$target"
+      printf 'Removed tmux session: %s\n' "$target"
+      while IFS= read -r companion; do
+        [[ -z "$companion" ]] && continue
+        tmux kill-session -t "$companion" 2>/dev/null \
+          && printf 'Removed companion session: %s\n' "$companion"
+      done < <(companions_of "$target")
+    else
+      printf 'No tmux session named: %s\n' "$target" >&2
+      status=1
+    fi
+  done
+```
+
+Also declare the new loop variable: in `session_kill_command`'s local declarations (currently `scripts/dev:200-202`), add `local companion` (append to the existing `local target` line or add a new `local` line).
+
+Note: `companions_of "$target"` is computed AFTER the parent is killed, but it reads the live `tmux list-sessions`, and killing a parent does not remove its companions (they are separate sessions), so they are still present and get cleaned up here. A companion target has no companions of its own, so passing a companion to `dev session kill` cleanly kills just it.
+
+- [ ] **Step 4: Group the listing output**
+
+In `scripts/dev`, in `session_list_command`, change the final emit (currently `scripts/dev:195-196`):
+
+```bash
+  sessions="$(filter_sessions "$filter")"
+  printf '%s\n' "$sessions"
+```
+
+to:
+
+```bash
+  sessions="$(filter_sessions "$filter")"
+  printf '%s\n' "$sessions" | sort
+```
+
+- [ ] **Step 5: Verify kill cascade with tmux (manual)**
+
+Run:
+```bash
+tmux new-session -d -s "demo-parent000" -c "$HOME"
+tmux new-session -d -s "demo-parent000+1" -c "$HOME"
+tmux new-session -d -s "demo-parent000+2" -c "$HOME"
+./scripts/dev session kill -s "demo-parent000"
+tmux has-session -t "demo-parent000+1" 2>/dev/null && echo "LEAK" || echo "companions gone"
+```
+Expected: output includes `Removed tmux session: demo-parent000`, `Removed companion session: demo-parent000+1`, `Removed companion session: demo-parent000+2`, then `companions gone`.
+
+- [ ] **Step 6: Run tests, lint, smoke**
+
+Run: `./scripts/test-dev-more.sh && ./scripts/lint-shell.sh && ./scripts/smoke-test-cli.sh`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/dev scripts/test-dev-more.sh
+git commit -m "Cascade companion kills and group companions in session list"
+```
+
+---
+
+## Task 6: Documentation and cheat sheet
+
+Bring `cheat`, the canonical usage doc, and any cheatsheet in line with the new command. (`usage()` was already updated in Task 4.)
+
+**Files:**
+- Modify: `scripts/cheat` (after the `dev --workspace` entry, currently `scripts/cheat:248`)
+- Modify: `docs/ai/USAGE.md` (Day-To-Day Commands list at `docs/ai/USAGE.md:41-48`; Session Model section at `docs/ai/USAGE.md:60-73`)
+- Modify (conditional): `docs/appendix/cheatsheet.md` only if it lists dev commands
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Add the cheat entry**
+
+In `scripts/cheat`, immediately AFTER the line `entry "dev --workspace" "Load tmuxp workspace YAML"` (`scripts/cheat:248`), add:
+
+```bash
+  entry "dev more"          "Open a new Kitty tab of terminals for a workstream"
+```
+
+- [ ] **Step 2: Add to the Day-To-Day Commands list**
+
+In `docs/ai/USAGE.md`, in the "Primary workflow commands" list, add immediately after the `- \`dev session kill -s NAME...\`` line:
+
+```markdown
+- `dev more [--session NAME]`
+```
+
+- [ ] **Step 3: Add a Session Model note**
+
+In `docs/ai/USAGE.md`, at the end of the "Session Model" section (after the line about Kitty tab titles, `docs/ai/USAGE.md:72-73`), add:
+
+```markdown
+For more terminal room in a workstream, `dev more` opens another Kitty tab of equally
+sized terminals backed by a companion session named `<session>+<n>`. Companions persist
+when their tab is closed and can be resumed from the `dev more` picker; killing the
+parent session with `dev session kill` also removes its companions.
+```
+
+- [ ] **Step 4: Check the cheatsheet**
+
+Run: `grep -n 'dev ' docs/appendix/cheatsheet.md || echo "no dev command list in cheatsheet"`
+- If it lists dev commands, add a `dev more` row in the same format as the surrounding rows.
+- If it prints `no dev command list in cheatsheet`, skip this file.
+
+- [ ] **Step 5: Validate docs and the full suite**
+
+Run:
+```bash
+./scripts/validate-doc-links.py
+./scripts/lint-shell.sh
+./scripts/smoke-test-cli.sh
+./scripts/test-dev-more.sh
+git diff --check
+```
+Expected: all pass; `git diff --check` reports no whitespace errors.
+
+- [ ] **Step 6: Confirm help text matches docs**
+
+Run: `./scripts/dev --help && ./scripts/cheat | grep -A1 'dev more'`
+Expected: `dev more` appears in both the script usage and the cheat output, with consistent wording.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/cheat docs/ai/USAGE.md docs/appendix/cheatsheet.md
+git commit -m "Document dev more in cheat sheet and usage docs"
+```
+
+(If the cheatsheet was not changed, drop it from the `git add`.)
+
+---
+
+## Manual end-to-end validation (after all tasks)
+
+These require a real kitty + tmux session and are not automated. Run once before opening the PR:
+
+- [ ] From inside a `dev` workstream tab, run `dev more`. Confirm a new kitty tab opens titled `<session>+1` with 4 equal terminal panes in the project directory.
+- [ ] Run `dev more` again. Confirm a second tab `<session>+2` opens.
+- [ ] `cmd+w` the `+1` tab. Run `dev more` and confirm the fzf picker appears with `* New companion (+1)` on top and `+2` listed; arrow to `+2` and confirm it resumes; press Escape on a fresh run and confirm nothing happens.
+- [ ] Run `dev more --new` and confirm it skips the picker and opens a fresh companion.
+- [ ] Run `dev session list` and confirm companions appear directly under their parent.
+- [ ] Run `dev session kill -s <parent>` and confirm companions are removed too.
+
+---
+
+## Self-Review notes
+
+- Spec coverage: command surface (Task 4), naming/lowest-free-slot (Task 2), new-vs-resume picker (Task 4), tiled layout + resize hook (Task 3), target resolution/auto-detect (Task 4), project-dir via `#{session_path}` (Task 4), persistent lifecycle + kill cascade + list grouping (Task 5), kitty-unavailable fallback (Task 4, `open_companion_tab`), `--count`/nonexistent-session/`--count<1` edge cases (Task 4 Step 6), testing (Tasks 1-5), docs (Task 6).
+- Type/name consistency: `companion_name`, `parent_of_session`, `is_companion`, `companions_of`, `next_companion_slot`, `create_companion_session`, `detached_companions`, `parse_picker_selection`, `pick_companion_action`, `open_companion_tab`, `dev_more_command` are defined once and referenced consistently across tasks.
+- `--resume` is intentionally unchanged: it already reopens all sessions (including companions) as kitty tabs, which is consistent with the persistent model.

--- a/docs/superpowers/specs/2026-06-30-dev-more-design.md
+++ b/docs/superpowers/specs/2026-06-30-dev-more-design.md
@@ -89,16 +89,14 @@ not.
 ## Project directory resolution
 
 Companion panes must open in the parent's project directory, but the session name is a
-one-way hash of that path and cannot be reversed. To resolve it, record the project
-path on the parent session at creation time and read it back when building a companion:
+one-way hash of that path and cannot be reversed. The script already solves this in
+`--restart`, which reads a session's working directory with
+`tmux display-message -p '#{session_path}'`. Reuse that established pattern: resolve the
+parent's project directory with `tmux display-message -p -t "<parent>" '#{session_path}'`.
 
-- In the existing `create_session`, add `tmux set-environment -t "$session"
-  DEV_PROJECT "$project"`.
-- In `dev more`, read it via `tmux show-environment -t "<parent>" DEV_PROJECT`.
-
-This is robust against cd-ing around inside panes. If the variable is missing (for
-example a session created before this change), fall back to the parent's first pane
-current path.
+This needs no change to `create_session`, since the parent session is created with
+`-c "<project>"` and `#{session_path}` reports that directory (verified on tmux 3.6a).
+If the value is ever empty, fall back to the parent's active `#{pane_current_path}`.
 
 ## Lifecycle and cleanup
 
@@ -122,16 +120,27 @@ current path.
 
 ## Testing
 
-- Factor the pure logic into small, testable functions: companion-name formatting,
-  lowest-free-slot allocation, and parent-from-companion-name parsing. Unit-test these
-  without tmux or kitty.
-- Add a tmux smoke test (tmux runs headless) that creates a parent plus a companion and
-  asserts the pane count and that the layout is `tiled`, with `kitty @ launch` stubbed.
-- Match whatever test harness the repo already uses, or add `bats` if there is none.
+The repo has no unit-test framework; its only automated check is
+`scripts/smoke-test-cli.sh` (runs `--help` on each command), plus `shellcheck` via
+`scripts/lint-shell.sh` and a doc-link validator. Tests for this feature follow that
+plain-bash style:
+
+- Add a `BASH_SOURCE` guard before the dispatch block in `scripts/dev` so the file can
+  be sourced (to load its functions) without running the command.
+- Add `scripts/test-dev-more.sh` (same plain-bash assertion style as
+  `smoke-test-cli.sh`). It sources `scripts/dev` and unit-tests the pure helpers:
+  companion-name formatting, parent-from-companion-name parsing, lowest-free-slot
+  allocation (stubbing `list_sessions`), and picker-selection parsing.
+- The same script includes a tmux-backed check, guarded by `command -v tmux`, that
+  creates a parent plus a companion and asserts the pane count and that the layout is
+  `tiled`. It is skipped when tmux is unavailable.
 
 ## Files touched
 
-- `scripts/dev`: new `more` subcommand and helpers; one line added to `create_session`
-  for `DEV_PROJECT`; cascade in `session kill`; grouping in `session list`.
-- Tests (harness confirmed during planning).
-- A short README or docs note describing `dev more`.
+- `scripts/dev`: a `BASH_SOURCE` guard so the file is sourceable for tests; new `more`
+  subcommand and helpers; cascade in `session kill`; grouping in `session list`;
+  updated `usage()` help text.
+- `scripts/test-dev-more.sh`: new test script for the pure helpers plus the tmux-backed
+  layout check.
+- `scripts/cheat` and `docs/ai/USAGE.md`: document `dev more`, plus
+  `docs/appendix/cheatsheet.md` if it lists dev commands.

--- a/docs/superpowers/specs/2026-06-30-dev-more-design.md
+++ b/docs/superpowers/specs/2026-06-30-dev-more-design.md
@@ -1,0 +1,137 @@
+# `dev more` design
+
+Date: 2026-06-30
+
+## Summary
+
+Add a `dev more` subcommand to `scripts/dev` that opens a new kitty tab containing
+several equally proportioned terminal panes tied to an existing workstream. The new
+tab does not mirror the parent's nvim layout; it is a fresh scratch space backed by
+its own tmux "companion" session that is namespaced to the parent.
+
+## Motivation
+
+The current `dev` layout gives one kitty tab per workstream with an nvim pane and two
+terminals (`main-vertical`). When working on several things at once, that is not
+enough terminal room. We want to spin up extra kitty tabs of terminals that belong to
+the same workstream, without disturbing the primary nvim layout and without the tmux
+mirroring problem described below.
+
+## Key constraint: tmux client mirroring
+
+Two clients (two kitty tabs) attached to the *same* tmux session always show the same
+active window and the same panes, and the window is resized down to the smaller of the
+two clients. A naive "attach a second kitty tab to the parent session" therefore shows
+a copy of the nvim layout, not fresh terminals. To get independent content per tab we
+use a separate tmux session per extra tab (a "companion" session), namespaced to the
+parent. This avoids mirroring and resize coupling entirely.
+
+## Command surface
+
+```
+dev more [--session <parent-id>] [--count N] [--new]
+```
+
+- `--session <id>`: the parent session, for example `repo-56e811`. Optional when run
+  from inside the workstream (see "Target resolution").
+- `--count N`: number of panes in the new tab. Default 4, laid out as an equal `tiled`
+  grid.
+- `--new`: skip the picker and force a brand-new companion even when resumable ones
+  exist.
+
+## Session and naming model
+
+Companions are real tmux sessions named `<parent>+<n>`, for example `repo-56e811+1`.
+The `+` character is tmux-safe; tmux session names only forbid `.` and `:`.
+
+A new companion claims the **lowest free slot**: the smallest integer `n` for which no
+session named `<parent>+<n>` exists. Killed slots are reused, so the numbers stay small
+and predictable.
+
+The kitty tab title is set to the companion name, matching how the parent tab is
+titled today, so the id can be read back off the tab.
+
+## The flow (new vs. resume)
+
+On `dev more`:
+
+1. Resolve the parent (see "Target resolution").
+2. List that parent's **detached** companions by filtering `tmux ls` to names matching
+   `^<parent>+<n>$`.
+3. If none are detached, or `--new` was passed: create the next companion, build the
+   panes, and open a kitty tab attached to it.
+4. If some exist: open an fzf picker with `New companion (+N)` preselected at the top
+   and the detached companions listed below, each with a preview of what is running in
+   it (`tmux list-panes` plus a short `capture-pane` peek). Pressing Enter creates a new
+   companion; selecting an existing one resumes it in a fresh tab.
+
+## Layout
+
+Build the companion detached, then split and tile:
+
+1. `tmux new-session -d -s "<companion>" -c "<project>"` for the first pane.
+2. `--count - 1` calls to `tmux split-window -c "<project>"`.
+3. `tmux select-layout -t "<companion>:1" tiled` for an equal grid.
+4. `tmux set-hook -t "<companion>" window-resized "select-layout tiled"` so the grid
+   stays balanced on resize.
+
+This mirrors the self-healing layout pattern the parent already uses with
+`main-vertical`. Companions contain only terminals; there is no nvim pane.
+
+## Target resolution
+
+If `--session` is omitted and we are inside tmux, derive the parent from the current
+session name by stripping any trailing `+<n>` suffix. This lets `dev more` work both
+from the parent tab and from inside a companion (to spawn a sibling). If `--session` is
+given, validate that it names a real session and exit non-zero with a clear message if
+not.
+
+## Project directory resolution
+
+Companion panes must open in the parent's project directory, but the session name is a
+one-way hash of that path and cannot be reversed. To resolve it, record the project
+path on the parent session at creation time and read it back when building a companion:
+
+- In the existing `create_session`, add `tmux set-environment -t "$session"
+  DEV_PROJECT "$project"`.
+- In `dev more`, read it via `tmux show-environment -t "<parent>" DEV_PROJECT`.
+
+This is robust against cd-ing around inside panes. If the variable is missing (for
+example a session created before this change), fall back to the parent's first pane
+current path.
+
+## Lifecycle and cleanup
+
+- Closing a companion tab (cmd+w) leaves its tmux session running detached, so it
+  appears in the picker next time. This is the persistent model.
+- `dev session kill <parent>` cascades to also kill `<parent>+<n>` companions, so
+  ending a workstream takes its scratch terminals with it.
+- `dev session list` groups companions under their parent in the listing.
+- On reboot, tmux-continuum restores companions as detached sessions. Kitty tabs are
+  not reopened automatically because continuum only restores tmux state. The picker
+  surfaces the restored companions so any can be brought back. This is consistent with
+  the persistent model and is documented so it is not surprising.
+
+## Edge cases and graceful degradation
+
+- Not running under kitty, or kitty remote control unavailable: still build the
+  session, then print the `tmux attach-session -t <companion>` command instead of
+  opening a tab, with a clear note.
+- `--session` names a nonexistent session: error and exit non-zero.
+- `--count` less than 1: reject with a message.
+
+## Testing
+
+- Factor the pure logic into small, testable functions: companion-name formatting,
+  lowest-free-slot allocation, and parent-from-companion-name parsing. Unit-test these
+  without tmux or kitty.
+- Add a tmux smoke test (tmux runs headless) that creates a parent plus a companion and
+  asserts the pane count and that the layout is `tiled`, with `kitty @ launch` stubbed.
+- Match whatever test harness the repo already uses, or add `bats` if there is none.
+
+## Files touched
+
+- `scripts/dev`: new `more` subcommand and helpers; one line added to `create_session`
+  for `DEV_PROJECT`; cascade in `session kill`; grouping in `session list`.
+- Tests (harness confirmed during planning).
+- A short README or docs note describing `dev more`.

--- a/scripts/cheat
+++ b/scripts/cheat
@@ -246,7 +246,7 @@ section_shell() {
   entry "dev --restart"   "Kill and restart current session"
   entry "dev --resume"    "Reopen all sessions as Kitty tabs"
   entry "dev --workspace" "Load tmuxp workspace YAML"
-  entry "dev more"          "Open a new Kitty tab of terminals for a workstream"
+  entry "dev more"       "Open a new Kitty tab of terminals for a workstream"
   entry "v / vim"        "Open Neovim"
   entry "lg"             "Open LazyGit"
   entry "tl"             "List tmux sessions"

--- a/scripts/cheat
+++ b/scripts/cheat
@@ -246,6 +246,7 @@ section_shell() {
   entry "dev --restart"   "Kill and restart current session"
   entry "dev --resume"    "Reopen all sessions as Kitty tabs"
   entry "dev --workspace" "Load tmuxp workspace YAML"
+  entry "dev more"          "Open a new Kitty tab of terminals for a workstream"
   entry "v / vim"        "Open Neovim"
   entry "lg"             "Open LazyGit"
   entry "tl"             "List tmux sessions"

--- a/scripts/dev
+++ b/scripts/dev
@@ -396,13 +396,14 @@ session_list_command() {
   fi
 
   sessions="$(filter_sessions "$filter")"
-  printf '%s\n' "$sessions"
+  printf '%s\n' "$sessions" | sort
 }
 
 session_kill_command() {
   local -a targets=()
   local status=0
   local target
+  local companion
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -438,6 +439,11 @@ session_kill_command() {
     if tmux has-session -t "$target" 2>/dev/null; then
       tmux kill-session -t "$target"
       printf 'Removed tmux session: %s\n' "$target"
+      while IFS= read -r companion; do
+        [[ -z "$companion" ]] && continue
+        tmux kill-session -t "$companion" 2>/dev/null \
+          && printf 'Removed companion session: %s\n' "$companion"
+      done < <(companions_of "$target")
     else
       printf 'No tmux session named: %s\n' "$target" >&2
       status=1

--- a/scripts/dev
+++ b/scripts/dev
@@ -16,6 +16,7 @@ Usage:
   dev install --local              Install your real setup from the current local clone
   dev session list [--filter TEXT] List tmux sessions managed by dev/tmux
   dev session kill -s NAME...      Kill one or more tmux sessions by name
+  dev more [--session NAME]        Open a new Kitty tab of terminals for a workstream
   dev --refresh                    Re-apply layout and settings to the current tmux session
   dev --restart                    Kill current session and start a fresh one for the same project
   dev --resume                     Reopen all tmux sessions as Kitty tabs
@@ -211,6 +212,158 @@ set_current_tab_title() {
   fi
 }
 
+# Detached companions of PARENT, reusing the tested companions_of helper.
+detached_companions() {
+  local parent="$1" name attached
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    attached="$(tmux display-message -p -t "$name" '#{session_attached}' 2>/dev/null || true)"
+    [[ "$attached" == "0" ]] && printf '%s\n' "$name"
+  done < <(companions_of "$parent")
+}
+
+parse_picker_selection() {
+  local line="$1"
+  printf '%s\n' "${line%%[[:space:]]*}"
+}
+
+# Decides what `dev more` should do. Prints "NEW", the chosen companion name, or
+# nothing (when the picker is cancelled). Falls back to "NEW" when nothing is
+# detached or when fzf is unavailable.
+pick_companion_action() {
+  local parent="$1" next_slot="$2"
+  local detached menu name panes selection
+  detached="$(detached_companions "$parent")"
+
+  if [[ -z "$detached" ]] || ! command -v fzf >/dev/null 2>&1; then
+    printf 'NEW\n'
+    return 0
+  fi
+
+  # Build the fzf menu at function scope (avoids `local` inside a subshell).
+  # Each line is "KEY<TAB>LABEL"; KEY is "NEW" or a session name (never has spaces).
+  menu="$(printf 'NEW\t* New companion (+%s)' "$next_slot")"
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    panes="$(tmux list-panes -t "$name" 2>/dev/null | wc -l | tr -d ' ')"
+    menu+="$(printf '\n%s\t+%s . %s panes' "$name" "${name##*+}" "$panes")"
+  done <<< "$detached"
+
+  # The fzf --preview string is a snippet fzf re-evaluates per row, so its $sel,
+  # {1}, and #{...} placeholders must stay literal (single-quoted) here.
+  # shellcheck disable=SC2016
+  selection="$(printf '%s\n' "$menu" | fzf --delimiter='\t' --with-nth=2.. \
+      --prompt='Companion > ' --height=50% --layout=reverse --border \
+      --preview 'sel={1}; if [ "$sel" = NEW ]; then echo "Open a new tab of terminals."; else tmux list-panes -t "$sel" -F "#{pane_index}: #{pane_current_command}  (#{pane_current_path})" 2>/dev/null; fi' \
+      --preview-window='right,45%')" || true
+
+  if [[ -z "$selection" ]]; then
+    # Picker cancelled (Escape).
+    return 0
+  fi
+
+  parse_picker_selection "$selection"
+}
+
+open_companion_tab() {
+  local name="$1"
+  if [[ -n "${KITTY_WINDOW_ID:-}" ]] && kitty_remote_available; then
+    kitty @ launch --type=tab --tab-title "$name" tmux attach-session -t "$name"
+  else
+    printf 'Kitty remote control is unavailable; attach with: tmux attach-session -t %s\n' "$name" >&2
+  fi
+}
+
+dev_more_command() {
+  local parent="" count=4 force_new=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --session)
+        parent="${2:-}"
+        if [[ -z "$parent" ]]; then
+          printf 'Usage: dev more [--session NAME] [--count N] [--new]\n' >&2
+          exit 1
+        fi
+        shift 2
+        ;;
+      --count)
+        count="${2:-}"
+        if [[ ! "$count" =~ ^[0-9]+$ ]] || [[ "$count" -lt 1 ]]; then
+          printf 'dev more: --count must be a positive integer\n' >&2
+          exit 1
+        fi
+        shift 2
+        ;;
+      --new)
+        force_new=1
+        shift
+        ;;
+      -h|--help)
+        cat <<'EOF'
+Usage: dev more [--session NAME] [--count N] [--new]
+
+Open a new Kitty tab of terminals tied to a workstream (a "companion" session).
+
+Options:
+  --session NAME  Parent session id (e.g. repo-56e811). Defaults to the current
+                  tmux session when run inside one.
+  --count N       Number of terminal panes in the new tab (default 4).
+  --new           Skip the resume picker and always create a fresh companion.
+EOF
+        exit 0
+        ;;
+      *)
+        printf 'Unknown option for dev more: %s\n' "$1" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ -z "$parent" ]]; then
+    if [[ -n "${TMUX:-}" ]]; then
+      parent="$(parent_of_session "$(tmux display-message -p '#S')")"
+    else
+      printf 'dev more: provide --session NAME or run inside a tmux session\n' >&2
+      exit 1
+    fi
+  fi
+
+  if ! tmux has-session -t "$parent" 2>/dev/null; then
+    printf 'dev more: no tmux session named: %s\n' "$parent" >&2
+    exit 1
+  fi
+
+  local project
+  project="$(tmux display-message -p -t "$parent" '#{session_path}')"
+  if [[ -z "$project" ]]; then
+    project="$(tmux display-message -p -t "$parent" '#{pane_current_path}')"
+  fi
+
+  local next_slot action target
+  next_slot="$(next_companion_slot "$parent")"
+
+  if [[ "$force_new" -eq 1 ]]; then
+    action="NEW"
+  else
+    action="$(pick_companion_action "$parent" "$next_slot")"
+  fi
+
+  if [[ -z "$action" ]]; then
+    # Picker cancelled.
+    exit 0
+  fi
+
+  if [[ "$action" == "NEW" ]]; then
+    target="$(companion_name "$parent" "$next_slot")"
+    create_companion_session "$target" "$project" "$count"
+  else
+    target="$action"
+  fi
+
+  open_companion_tab "$target"
+}
+
 session_list_command() {
   local filter=""
   local sessions
@@ -384,6 +537,12 @@ if [[ "${1:-}" == "session" ]]; then
       exit 1
       ;;
   esac
+  exit 0
+fi
+
+if [[ "${1:-}" == "more" ]]; then
+  shift
+  dev_more_command "$@"
   exit 0
 fi
 

--- a/scripts/dev
+++ b/scripts/dev
@@ -47,10 +47,6 @@ companion_name() {
   printf '%s+%s\n' "$parent" "$slot"
 }
 
-is_companion() {
-  [[ "$1" =~ \+[0-9]+$ ]]
-}
-
 parent_of_session() {
   local name="$1"
   printf '%s\n' "${name%+[0-9]*}"
@@ -229,13 +225,13 @@ parse_picker_selection() {
 
 # Decides what `dev more` should do. Prints "NEW", the chosen companion name, or
 # nothing (when the picker is cancelled). Falls back to "NEW" when nothing is
-# detached or when fzf is unavailable.
+# detached.
 pick_companion_action() {
   local parent="$1" next_slot="$2"
   local detached menu name panes selection
   detached="$(detached_companions "$parent")"
 
-  if [[ -z "$detached" ]] || ! command -v fzf >/dev/null 2>&1; then
+  if [[ -z "$detached" ]]; then
     printf 'NEW\n'
     return 0
   fi
@@ -404,6 +400,7 @@ session_kill_command() {
   local status=0
   local target
   local companion
+  local killed=" "
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -438,12 +435,17 @@ session_kill_command() {
   for target in "${targets[@]}"; do
     if tmux has-session -t "$target" 2>/dev/null; then
       tmux kill-session -t "$target"
+      killed+="$target "
       printf 'Removed tmux session: %s\n' "$target"
       while IFS= read -r companion; do
         [[ -z "$companion" ]] && continue
-        tmux kill-session -t "$companion" 2>/dev/null \
-          && printf 'Removed companion session: %s\n' "$companion"
+        if tmux kill-session -t "$companion" 2>/dev/null; then
+          killed+="$companion "
+          printf 'Removed companion session: %s\n' "$companion"
+        fi
       done < <(companions_of "$target")
+    elif [[ "$killed" == *" $target "* ]]; then
+      : # already removed earlier this run (e.g. cascaded as a companion); not an error
     else
       printf 'No tmux session named: %s\n' "$target" >&2
       status=1

--- a/scripts/dev
+++ b/scripts/dev
@@ -185,6 +185,20 @@ create_session() {
   tmux select-pane -t "${session}:1.2"
 }
 
+create_companion_session() {
+  local session="$1" project="$2" count="$3"
+  local i
+  tmux new-session -d -s "$session" -c "$project"
+  for ((i = 1; i < count; i++)); do
+    tmux split-window -c "$project" -t "${session}:1"
+    tmux select-layout -t "${session}:1" tiled
+  done
+  tmux source-file ~/.config/tmux/tmux.conf
+  tmux select-layout -t "${session}:1" tiled
+  tmux set-hook -t "$session" window-resized "select-layout tiled"
+  tmux select-pane -t "${session}:1.1"
+}
+
 kitty_remote_available() {
   command -v kitty >/dev/null 2>&1 && kitty @ ls >/dev/null 2>&1
 }

--- a/scripts/dev
+++ b/scripts/dev
@@ -41,6 +41,42 @@ session_name_for_project() {
   printf '%s-%s\n' "$base" "$hash"
 }
 
+companion_name() {
+  local parent="$1" slot="$2"
+  printf '%s+%s\n' "$parent" "$slot"
+}
+
+is_companion() {
+  [[ "$1" =~ \+[0-9]+$ ]]
+}
+
+parent_of_session() {
+  local name="$1"
+  printf '%s\n' "${name%+[0-9]*}"
+}
+
+companions_of() {
+  local parent="$1"
+  list_sessions | grep -E "^${parent}\+[0-9]+$" || true
+}
+
+next_companion_slot() {
+  local parent="$1"
+  local name slots n
+  # Collect used slot numbers (no associative arrays; macOS ships bash 3.2).
+  slots="$(
+    while IFS= read -r name; do
+      [[ -z "$name" ]] && continue
+      printf '%s\n' "${name##*+}"
+    done < <(companions_of "$parent") | sort -n
+  )"
+  n=1
+  while printf '%s\n' "$slots" | grep -qx "$n"; do
+    n=$((n + 1))
+  done
+  printf '%s\n' "$n"
+}
+
 list_roots() {
   local candidates=(
     "$PWD"

--- a/scripts/dev
+++ b/scripts/dev
@@ -307,6 +307,12 @@ EOF
   )
 }
 
+# When this file is sourced (e.g. by scripts/test-dev-more.sh) rather than
+# executed, stop here so only the function definitions above are loaded.
+if [[ "${BASH_SOURCE[0]:-}" != "${0}" ]]; then
+  return 0
+fi
+
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   usage
   exit 0

--- a/scripts/test-dev-more.sh
+++ b/scripts/test-dev-more.sh
@@ -39,11 +39,6 @@ check_status() {
 check "companion_name basic" "repo-56e811+1" "$(companion_name "repo-56e811" 1)"
 check "companion_name two digit" "repo-56e811+12" "$(companion_name "repo-56e811" 12)"
 
-# --- is_companion ---
-check_status "is_companion true" 0 is_companion "repo-56e811+2"
-check_status "is_companion false (parent)" 1 is_companion "repo-56e811"
-check_status "is_companion false (plus no digit)" 1 is_companion "repo-56e811+x"
-
 # --- parent_of_session ---
 check "parent_of_session strips suffix" "repo-56e811" "$(parent_of_session "repo-56e811+3")"
 check "parent_of_session passthrough" "repo-56e811" "$(parent_of_session "repo-56e811")"
@@ -58,21 +53,21 @@ repo-56e811+3" "$(companions_of "repo-56e811")"
 check "next_companion_slot fills gap" "2" "$(next_companion_slot "repo-56e811")"
 check "next_companion_slot first free" "2" "$(next_companion_slot "other-abc123")"
 
-list_sessions() { printf '%s\n' "repo-56e811"; }
-check "next_companion_slot none used" "1" "$(next_companion_slot "repo-56e811")"
-
 # --- parse_picker_selection (use $'\t' so the tab is unambiguous) ---
 check "parse_picker_selection NEW" "NEW" "$(parse_picker_selection $'NEW\t* New companion (+3)')"
 check "parse_picker_selection name" "repo-56e811+1" "$(parse_picker_selection $'repo-56e811+1\t+1 . 4 panes')"
 check "parse_picker_selection empty" "" "$(parse_picker_selection "")"
 
-# --- session listing groups companions under their parent (via sort) ---
-group_sample="$(printf '%s\n' "repo-56e811+2" "other-abc123" "repo-56e811" "repo-56e811+1" | sort)"
+# --- session_list_command groups companions directly under their parent ---
+list_sessions() { printf '%s\n' "repo-56e811+2" "other-abc123" "repo-56e811" "repo-56e811+1"; }
 group_expected="other-abc123
 repo-56e811
 repo-56e811+1
 repo-56e811+2"
-check "companion grouping sort order" "$group_expected" "$group_sample"
+check "session_list_command groups companions" "$group_expected" "$(session_list_command)"
+
+list_sessions() { printf '%s\n' "repo-56e811"; }
+check "next_companion_slot none used" "1" "$(next_companion_slot "repo-56e811")"
 
 # --- create_companion_session (tmux-backed; skipped without tmux) ---
 if command -v tmux >/dev/null 2>&1; then
@@ -89,8 +84,8 @@ if command -v tmux >/dev/null 2>&1; then
 
   # A 4-pane tiled layout is always a 2x2 grid: two distinct column offsets and
   # two distinct row offsets. A wrong layout (e.g. main-vertical) would give 3 rows.
-  distinct_left="$(tmux list-panes -t "${test_companion}:1" -F '#{pane_left}' | sort -u | wc -l | tr -d ' ')"
-  distinct_top="$(tmux list-panes -t "${test_companion}:1" -F '#{pane_top}' | sort -u | wc -l | tr -d ' ')"
+  distinct_left="$(tmux list-panes -t "${test_companion}:1" -F '#{pane_left}' 2>/dev/null | sort -u | wc -l | tr -d ' ')"
+  distinct_top="$(tmux list-panes -t "${test_companion}:1" -F '#{pane_top}' 2>/dev/null | sort -u | wc -l | tr -d ' ')"
   check "create_companion_session tiled 2x2 (2 columns)" "2" "$distinct_left"
   check "create_companion_session tiled 2x2 (2 rows)" "2" "$distinct_top"
 
@@ -103,6 +98,27 @@ if command -v tmux >/dev/null 2>&1; then
   trap - EXIT
 else
   printf '[skip] create_companion_session (tmux not available)\n'
+fi
+
+# --- regression: `dev session kill` with parent AND companion listed together
+#     must succeed (exit 0) with no false "No tmux session named" error.
+if command -v tmux >/dev/null 2>&1; then
+  kp="devmorekilltest-$$"
+  tmux new-session -d -s "$kp" -c "$HOME" 2>/dev/null
+  tmux new-session -d -s "${kp}+1" -c "$HOME" 2>/dev/null
+  tmux new-session -d -s "${kp}+2" -c "$HOME" 2>/dev/null
+  trap 'for s in "$kp" "${kp}+1" "${kp}+2"; do tmux kill-session -t "$s" 2>/dev/null || true; done' EXIT
+
+  kill_rc=0
+  kill_out="$("${SCRIPT_DIR}/dev" session kill -s "$kp" -s "${kp}+1" 2>&1)" || kill_rc=$?
+  check "session kill parent+companion exits 0" "0" "$kill_rc"
+  check "session kill parent+companion no false error" "" "$(printf '%s\n' "$kill_out" | grep 'No tmux session named' || true)"
+  check_status "session kill cascaded +2 also gone" 1 tmux has-session -t "${kp}+2"
+
+  for s in "$kp" "${kp}+1" "${kp}+2"; do tmux kill-session -t "$s" 2>/dev/null || true; done
+  trap - EXIT
+else
+  printf '[skip] session kill parent+companion regression (tmux not available)\n'
 fi
 
 printf '\n%d run, %d failed\n' "$tests_run" "$tests_failed"

--- a/scripts/test-dev-more.sh
+++ b/scripts/test-dev-more.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Resolve repo root from this script's location so the test can be run from anywhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/dev
+source "${SCRIPT_DIR}/dev"
+
+tests_run=0
+tests_failed=0
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  tests_run=$((tests_run + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    printf '[pass] %s\n' "$label"
+  else
+    tests_failed=$((tests_failed + 1))
+    printf '[FAIL] %s\n  expected: %q\n  actual:   %q\n' "$label" "$expected" "$actual"
+  fi
+}
+
+check_status() {
+  local label="$1" expected_status="$2"
+  shift 2
+  local actual_status=0
+  "$@" >/dev/null 2>&1 || actual_status=$?
+  tests_run=$((tests_run + 1))
+  if [[ "$expected_status" -eq "$actual_status" ]]; then
+    printf '[pass] %s\n' "$label"
+  else
+    tests_failed=$((tests_failed + 1))
+    printf '[FAIL] %s\n  expected status: %s\n  actual status:   %s\n' "$label" "$expected_status" "$actual_status"
+  fi
+}
+
+# --- companion_name ---
+check "companion_name basic" "repo-56e811+1" "$(companion_name "repo-56e811" 1)"
+check "companion_name two digit" "repo-56e811+12" "$(companion_name "repo-56e811" 12)"
+
+# --- is_companion ---
+check_status "is_companion true" 0 is_companion "repo-56e811+2"
+check_status "is_companion false (parent)" 1 is_companion "repo-56e811"
+check_status "is_companion false (plus no digit)" 1 is_companion "repo-56e811+x"
+
+# --- parent_of_session ---
+check "parent_of_session strips suffix" "repo-56e811" "$(parent_of_session "repo-56e811+3")"
+check "parent_of_session passthrough" "repo-56e811" "$(parent_of_session "repo-56e811")"
+check "parent_of_session two-digit suffix" "repo-56e811" "$(parent_of_session "repo-56e811+10")"
+
+# --- companions_of + next_companion_slot (stub list_sessions) ---
+list_sessions() {
+  printf '%s\n' "repo-56e811" "repo-56e811+1" "repo-56e811+3" "other-abc123" "other-abc123+1"
+}
+check "companions_of filters to parent" "repo-56e811+1
+repo-56e811+3" "$(companions_of "repo-56e811")"
+check "next_companion_slot fills gap" "2" "$(next_companion_slot "repo-56e811")"
+check "next_companion_slot first free" "2" "$(next_companion_slot "other-abc123")"
+
+list_sessions() { printf '%s\n' "repo-56e811"; }
+check "next_companion_slot none used" "1" "$(next_companion_slot "repo-56e811")"
+
+printf '\n%d run, %d failed\n' "$tests_run" "$tests_failed"
+[[ "$tests_failed" -eq 0 ]]

--- a/scripts/test-dev-more.sh
+++ b/scripts/test-dev-more.sh
@@ -66,6 +66,14 @@ check "parse_picker_selection NEW" "NEW" "$(parse_picker_selection $'NEW\t* New 
 check "parse_picker_selection name" "repo-56e811+1" "$(parse_picker_selection $'repo-56e811+1\t+1 . 4 panes')"
 check "parse_picker_selection empty" "" "$(parse_picker_selection "")"
 
+# --- session listing groups companions under their parent (via sort) ---
+group_sample="$(printf '%s\n' "repo-56e811+2" "other-abc123" "repo-56e811" "repo-56e811+1" | sort)"
+group_expected="other-abc123
+repo-56e811
+repo-56e811+1
+repo-56e811+2"
+check "companion grouping sort order" "$group_expected" "$group_sample"
+
 # --- create_companion_session (tmux-backed; skipped without tmux) ---
 if command -v tmux >/dev/null 2>&1; then
   test_parent="devmoretest-$$"

--- a/scripts/test-dev-more.sh
+++ b/scripts/test-dev-more.sh
@@ -61,5 +61,36 @@ check "next_companion_slot first free" "2" "$(next_companion_slot "other-abc123"
 list_sessions() { printf '%s\n' "repo-56e811"; }
 check "next_companion_slot none used" "1" "$(next_companion_slot "repo-56e811")"
 
+# --- create_companion_session (tmux-backed; skipped without tmux) ---
+if command -v tmux >/dev/null 2>&1; then
+  test_parent="devmoretest-$$"
+  test_companion="${test_parent}+1"
+  test_dir="$(mktemp -d)"
+  # Ensure cleanup even on failure.
+  trap 'tmux kill-session -t "$test_companion" 2>/dev/null || true; rm -rf "$test_dir"' EXIT
+
+  create_companion_session "$test_companion" "$test_dir" 4
+
+  pane_count="$(tmux list-panes -t "${test_companion}:1" 2>/dev/null | wc -l | tr -d ' ')"
+  check "create_companion_session pane count" "4" "$pane_count"
+
+  # A 4-pane tiled layout is always a 2x2 grid: two distinct column offsets and
+  # two distinct row offsets. A wrong layout (e.g. main-vertical) would give 3 rows.
+  distinct_left="$(tmux list-panes -t "${test_companion}:1" -F '#{pane_left}' | sort -u | wc -l | tr -d ' ')"
+  distinct_top="$(tmux list-panes -t "${test_companion}:1" -F '#{pane_top}' | sort -u | wc -l | tr -d ' ')"
+  check "create_companion_session tiled 2x2 (2 columns)" "2" "$distinct_left"
+  check "create_companion_session tiled 2x2 (2 rows)" "2" "$distinct_top"
+
+  first_pane_path="$(tmux display-message -p -t "${test_companion}:1.1" '#{pane_current_path}')"
+  # macOS reports the mktemp dir through its /private symlink; normalize both sides.
+  check "create_companion_session cwd" "$(cd "$test_dir" && pwd -P)" "$(cd "$first_pane_path" && pwd -P)"
+
+  tmux kill-session -t "$test_companion" 2>/dev/null || true
+  rm -rf "$test_dir"
+  trap - EXIT
+else
+  printf '[skip] create_companion_session (tmux not available)\n'
+fi
+
 printf '\n%d run, %d failed\n' "$tests_run" "$tests_failed"
 [[ "$tests_failed" -eq 0 ]]

--- a/scripts/test-dev-more.sh
+++ b/scripts/test-dev-more.sh
@@ -61,6 +61,11 @@ check "next_companion_slot first free" "2" "$(next_companion_slot "other-abc123"
 list_sessions() { printf '%s\n' "repo-56e811"; }
 check "next_companion_slot none used" "1" "$(next_companion_slot "repo-56e811")"
 
+# --- parse_picker_selection (use $'\t' so the tab is unambiguous) ---
+check "parse_picker_selection NEW" "NEW" "$(parse_picker_selection $'NEW\t* New companion (+3)')"
+check "parse_picker_selection name" "repo-56e811+1" "$(parse_picker_selection $'repo-56e811+1\t+1 . 4 panes')"
+check "parse_picker_selection empty" "" "$(parse_picker_selection "")"
+
 # --- create_companion_session (tmux-backed; skipped without tmux) ---
 if command -v tmux >/dev/null 2>&1; then
   test_parent="devmoretest-$$"


### PR DESCRIPTION
## What

Adds a `dev more` subcommand that opens a new Kitty tab of equally proportioned terminal panes tied to an existing workstream, without disturbing the primary nvim layout.

```
dev more [--session NAME] [--count N] [--new]
```

## Why

The standard `dev` layout gives one Kitty tab per workstream (nvim plus two terminals via `main-vertical`). When juggling several things at once that is not enough terminal room. `dev more` adds extra tabs of terminals that belong to the same workstream.

## How it works

Two Kitty tabs attached to the same tmux session mirror each other (same window, and the window resizes down to the smaller client). To give each extra tab its own terminals, `dev more` backs each tab with its own "companion" tmux session named `<parent>+<n>` (for example `repo-56e811+1`):

- Companions are built detached with `--count` panes (default 4) in a `tiled` grid, with a `window-resized` hook that re-applies `tiled`, mirroring how the primary layout self-heals.
- A new companion claims the lowest free slot. The parent is resolved from `--session` or, when run inside tmux, from the current session name (stripping any `+<n>` suffix). The project directory is resolved via `#{session_path}`, reusing the pattern `--restart` already uses.
- Companions persist when their tab is closed. Re-running `dev more` shows an fzf picker (`New companion` preselected on top, detached companions below with a preview of what is running); pressing Enter makes a fresh tab, or you can resume a parked one. `--new` skips the picker.
- `dev session kill <parent>` cascades to its companions, and `dev session list` groups companions directly under their parent.

## Design docs

The full design and the task-by-task implementation plan are committed in the branch:

- Spec: `docs/superpowers/specs/2026-06-30-dev-more-design.md`
- Plan: `docs/superpowers/plans/2026-06-30-dev-more.md`

## Testing

- New `scripts/test-dev-more.sh` unit-tests the pure helpers (name formatting, lowest-free-slot allocation, parent parsing, picker-selection parsing, listing grouping) and adds tmux-backed checks for the tiled layout and the kill cascade. Includes a regression test for the case where a parent and one of its companions are listed together in `dev session kill`.
- Full repo verification passes: `./scripts/lint-shell.sh`, `./scripts/test-dev-more.sh` (20/20), `./scripts/smoke-test-cli.sh`, `./scripts/validate-doc-links.py`, `git diff --check`.
- Docs updated in sync: `usage()` help, `scripts/cheat`, and `docs/ai/USAGE.md`.

Built with bash 3.2 compatibility and `set -euo pipefail` safety throughout; shellcheck clean.
